### PR TITLE
feat: centralize URL handling with baseUrl utility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 # Static Environment Variables
-NEXT_PUBLIC_BASE_URL=http://localhost:3000
 BASE_URL=http://localhost:3000
 # Used to redirect to /dashboard after sign in
 CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/dashboard

--- a/lib/payments/stripe.ts
+++ b/lib/payments/stripe.ts
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { User } from "@/lib/db/schema";
 import { updateUserSubscription } from "@/lib/db/queries";
 import { auth, currentUser } from "@clerk/nextjs/server";
+import { baseUrl } from "@/lib/utils";
 
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2024-06-20",
@@ -29,8 +30,8 @@ export async function createCheckoutSession({
       },
     ],
     mode: "subscription",
-    success_url: `${process.env.BASE_URL}/api/stripe/checkout?session_id={CHECKOUT_SESSION_ID}`,
-    cancel_url: `${process.env.BASE_URL}/pricing`,
+    success_url: `${baseUrl()}/api/stripe/checkout?session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${baseUrl()}/pricing`,
     customer: user.stripeCustomerId || undefined,
     client_reference_id: user.id.toString(),
     allow_promotion_codes: true,
@@ -102,7 +103,7 @@ export async function createCustomerPortalSession(user: User) {
 
   return stripe.billingPortal.sessions.create({
     customer: user.stripeCustomerId,
-    return_url: `${process.env.BASE_URL}/dashboard`,
+    return_url: `${baseUrl()}/dashboard`,
     configuration: configuration.id,
   });
 }

--- a/lib/setup.ts
+++ b/lib/setup.ts
@@ -290,12 +290,10 @@ async function main() {
   const { publishableKey: NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY, secretKey: CLERK_SECRET_KEY } = await promptForClerkKeys();
   const ANTHROPIC_API_KEY = await promptForAnthropicApiKey();
   await promptForGitHubOAuth();
-  const NEXT_PUBLIC_BASE_URL = 'http://localhost:3000';
   const BASE_URL = 'http://localhost:3000';
   const CLERK_SIGN_IN_FALLBACK_REDIRECT_URL = '/dashboard';
 
   await writeEnvFile({
-    NEXT_PUBLIC_BASE_URL,
     BASE_URL,
     CLERK_SIGN_IN_FALLBACK_REDIRECT_URL,
     STRIPE_SECRET_KEY,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function baseUrl() {
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`
+  }
+  if (process.env.BASE_URL) {
+    return process.env.BASE_URL
+  }
+  throw new Error('No base URL found. Please set BASE_URL or deploy to Vercel.')
+}


### PR DESCRIPTION
- Remove redundant NEXT_PUBLIC_BASE_URL as it's unused
- Add baseUrl() utility function that prioritizes VERCEL_URL over BASE_URL
- Update Stripe checkout and portal URLs to use baseUrl()
- Simplify setup script to only set BASE_URL for local development

This change ensures consistent URL handling across environments, with 
Vercel deployments automatically using the correct URL and local development 
falling back to BASE_URL.