### PR TITLE
chore(cli): replace TestResult with TestRun

### DIFF
--- a/packages/shortest/src/core/runner/test-reporter.ts
+++ b/packages/shortest/src/core/runner/test-reporter.ts
@@ -1,6 +1,7 @@
 import pc from "picocolors";
-import { FileResult, TestResult, TestStatus } from "@/core/runner/index";
+import { FileResult, TestStatus } from "@/core/runner/index";
 import { TestCase } from "@/core/runner/test-case";
+import { TestRun } from "@/core/runner/test-run";
 import { getLogger, Log } from "@/log/index";
 import { AssertionError } from "@/types/test";
 
@@ -49,9 +50,9 @@ export class TestReporter {
     this.reporterLog.setGroup(test.name);
   }
 
-  onTestEnd(testResult: TestResult) {
+  onTestEnd(testRun: TestRun) {
     this.log.trace("onTestEnd called");
-    switch (testResult.status) {
+    switch (testRun.status) {
       case "passed":
         this.passedTestsCount++;
         break;
@@ -60,33 +61,33 @@ export class TestReporter {
         break;
     }
     let testAICost = 0;
-    if (testResult.tokenUsage) {
-      this.totalPromptTokens += testResult.tokenUsage.promptTokens;
-      this.totalCompletionTokens += testResult.tokenUsage.completionTokens;
+    if (testRun.tokenUsage) {
+      this.totalPromptTokens += testRun.tokenUsage.promptTokens;
+      this.totalCompletionTokens += testRun.tokenUsage.completionTokens;
       testAICost = this.calculateCost(
-        testResult.tokenUsage.promptTokens,
-        testResult.tokenUsage.completionTokens,
+        testRun.tokenUsage.promptTokens,
+        testRun.tokenUsage.completionTokens,
       );
       this.aiCost += testAICost;
     }
-    const symbol = testResult.status === "passed" ? "✓" : "✗";
-    const color = testResult.status === "passed" ? pc.green : pc.red;
+    const symbol = testRun.status === "passed" ? "✓" : "✗";
+    const color = testRun.status === "passed" ? pc.green : pc.red;
 
-    this.reporterLog.info(`${color(`${symbol} ${testResult.status}`)}`);
-    if (testResult.tokenUsage.totalTokens > 0) {
+    this.reporterLog.info(`${color(`${symbol} ${testRun.status}`)}`);
+    if (testRun.tokenUsage.totalTokens > 0) {
       const cost = this.calculateCost(
-        testResult.tokenUsage.promptTokens,
-        testResult.tokenUsage.completionTokens,
+        testRun.tokenUsage.promptTokens,
+        testRun.tokenUsage.completionTokens,
       );
       this.reporterLog.info(
         pc.dim("↳"),
-        pc.dim(`${testResult.tokenUsage.totalTokens.toLocaleString()} tokens`),
+        pc.dim(`${testRun.tokenUsage.totalTokens.toLocaleString()} tokens`),
         pc.dim(`(≈ $${cost.toFixed(2)})`),
       );
     }
 
-    if (testResult.status === "failed") {
-      this.error("Reason", testResult.reason);
+    if (testRun.status === "failed") {
+      this.error("Reason", testRun.reason!);
     }
 
     this.reporterLog.resetGroup();

--- a/packages/shortest/src/core/runner/test-run.ts
+++ b/packages/shortest/src/core/runner/test-run.ts
@@ -1,0 +1,113 @@
+import path from "path";
+import { CACHE_DIR_PATH } from "@/cache";
+import { TestStatus } from "@/core/runner";
+import { TestCase } from "@/core/runner/test-case";
+import { TokenUsage } from "@/types/ai";
+import { ShortestError } from "@/utils/errors";
+
+// eslint-disable-next-line zod/require-zod-schema-types
+type TestRunState =
+  | { status: Extract<TestStatus, "failed" | "passed">; reason: string }
+  | { status: Extract<TestStatus, "pending" | "running">; reason?: string };
+
+/**
+ * Represents a single test execution with state management and token tracking.
+ *
+ * @class
+ * @example
+ * ```typescript
+ * const testRun = new TestRun(testCase);
+ * testRun.markRunning();
+ * testRun.markPassed({ reason: "Test passed" });
+ * ```
+ *
+ * @see {@link TestCase} for test case structure
+ * @see {@link TokenUsage} for token tracking
+ */
+export class TestRun {
+  private readonly testCase: TestCase;
+  private state: TestRunState = { status: "pending" } as TestRunState;
+
+  get status() {
+    return this.state.status;
+  }
+
+  get reason() {
+    return this.state.reason;
+  }
+
+  public tokenUsage: TokenUsage = {
+    completionTokens: 0,
+    promptTokens: 0,
+    totalTokens: 0,
+  };
+  private cacheKey: string;
+  private cacheFileName: string;
+  private cacheDir: string;
+
+  /**
+   * Creates a new test run instance
+   * @param {TestCase} testCase - Test case to execute
+   *
+   * @private
+   */
+  constructor(testCase: TestCase) {
+    this.testCase = testCase;
+    const startedAt = new Date();
+    const formattedStartedAt = startedAt.toISOString().replace(/[:.]/g, "-");
+    this.cacheKey = `${formattedStartedAt}_${this.testCase.identifier}`;
+    this.cacheFileName = `${this.cacheKey}.json`;
+    this.cacheDir = path.join(CACHE_DIR_PATH, this.cacheKey);
+  }
+
+  /**
+   * Marks the test as running
+   * @throws {ShortestError} If test is not in pending state
+   */
+  markRunning() {
+    if (this.status !== "pending")
+      throw new ShortestError("Can only start from pending state");
+    this.state = { status: "running" };
+  }
+
+  /**
+   * Marks the test as passed
+   * @param {Object} options - Pass options
+   * @param {string} options.reason - Reason for passing
+   * @param {TokenUsage} [options.tokenUsage] - Optional token usage stats
+   * @throws {ShortestError} If test is not in running state
+   *
+   * @private
+   */
+  markPassed({
+    reason,
+    tokenUsage,
+  }: {
+    reason: string;
+    tokenUsage?: TokenUsage;
+  }) {
+    if (this.status !== "running")
+      throw new ShortestError("Can only pass from running state");
+    this.state = { status: "passed", reason };
+    if (tokenUsage) this.tokenUsage = tokenUsage;
+  }
+
+  /**
+   * Marks the test as failed
+   * @param {Object} options - Fail options
+   * @param {string} options.reason - Reason for failure
+   * @param {TokenUsage} [options.tokenUsage] - Optional token usage stats
+   *
+   * @private
+   */
+  markFailed({
+    reason,
+    tokenUsage,
+  }: {
+    reason: string;
+    tokenUsage?: TokenUsage;
+  }) {
+    this.state = { status: "failed", reason };
+    if (tokenUsage) this.tokenUsage = tokenUsage;
+  }
+}

--- a/packages/shortest/tests/unit/core/runner/test-run.test.ts
+++ b/packages/shortest/tests/unit/core/runner/test-run.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from "vitest";
+import { createTestCase } from "@/core/runner/test-case";
+import { TestRun } from "@/core/runner/test-run";
+
+describe("test-run", () => {
+  const mockTestCase = createTestCase({
+    name: "test case",
+    filePath: "/test.ts",
+  });
+
+  test("initializes with pending status", () => {
+    const testRun = new TestRun(mockTestCase);
+    expect(testRun.status).toBe("pending");
+    expect(testRun.reason).toBeUndefined();
+  });
+
+  test("transitions from pending to running", () => {
+    const testRun = new TestRun(mockTestCase);
+    testRun.markRunning();
+    expect(testRun.status).toBe("running");
+    expect(testRun.reason).toBeUndefined();
+  });
+
+  test("transitions from running to passed", () => {
+    const testRun = new TestRun(mockTestCase);
+    testRun.markRunning();
+    testRun.markPassed({ reason: "test passed" });
+    expect(testRun.status).toBe("passed");
+    expect(testRun.reason).toBe("test passed");
+  });
+
+  test("transitions from running to failed", () => {
+    const testRun = new TestRun(mockTestCase);
+    testRun.markRunning();
+    testRun.markFailed({ reason: "test failed" });
+    expect(testRun.status).toBe("failed");
+    expect(testRun.reason).toBe("test failed");
+  });
+
+  test("tracks token usage", () => {
+    const testRun = new TestRun(mockTestCase);
+    const usage = {
+      completionTokens: 10,
+      promptTokens: 20,
+      totalTokens: 30,
+    };
+    testRun.markRunning();
+    testRun.markPassed({ reason: "test passed", tokenUsage: usage });
+    expect(testRun.tokenUsage).toEqual(usage);
+  });
+
+  test("updates token usage on state change", () => {
+    const testRun = new TestRun(mockTestCase);
+    const usage = {
+      completionTokens: 10,
+      promptTokens: 20,
+      totalTokens: 30,
+    };
+    testRun.markRunning();
+    testRun.markPassed({ reason: "test passed", tokenUsage: usage });
+    expect(testRun.tokenUsage).toEqual(usage);
+  });
+
+  test("throws when marking running from non-pending state", () => {
+    const testRun = new TestRun(mockTestCase);
+    testRun.markRunning();
+    expect(() => testRun.markRunning()).toThrow(
+      "Can only start from pending state",
+    );
+  });
+
+  test("throws when marking passed from non-running state", () => {
+    const testRun = new TestRun(mockTestCase);
+    expect(() => testRun.markPassed({ reason: "test passed" })).toThrow(
+      "Can only pass from running state",
+    );
+  });
+});


### PR DESCRIPTION
In preparation for https://github.com/antiwork/shortest/pull/387

Extract test execution state management into a dedicated `TestRun` class, replacing the previous `TestResult` type. This improves encapsulation of test state transitions (pending -> running -> passed/failed) and token usage tracking.
In #387, `TestRun` will be used to set the timestamp when the test runs starts, so that can it can be used to store screenshots in a folder having the same name as the test run cache file.
