### PR TITLE
feat: add plan command

### DIFF
--- a/packages/shortest/src/cli/bin.ts
+++ b/packages/shortest/src/cli/bin.ts
@@ -8,6 +8,7 @@ import {
   clearCommand,
   detectFrameworkCommand,
   analyzeCommand,
+  planCommand,
 } from "@/cli/commands";
 import { getLogger } from "@/log/index";
 import { ShortestError } from "@/utils/errors";
@@ -38,6 +39,9 @@ detectFrameworkCommand.copyInheritedSettings(shortestCommand);
 
 shortestCommand.addCommand(analyzeCommand);
 analyzeCommand.copyInheritedSettings(shortestCommand);
+
+shortestCommand.addCommand(planCommand);
+planCommand.copyInheritedSettings(shortestCommand);
 
 const main = async () => {
   try {

--- a/packages/shortest/src/cli/commands/index.ts
+++ b/packages/shortest/src/cli/commands/index.ts
@@ -3,6 +3,7 @@ import { cacheCommands, clearCommand } from "@/cli/commands/cache";
 import { detectFrameworkCommand } from "@/cli/commands/detect-framework";
 import { githubCodeCommand } from "@/cli/commands/github-code";
 import { initCommand } from "@/cli/commands/init";
+import { planCommand } from "@/cli/commands/plan";
 import { shortestCommand } from "@/cli/commands/shortest";
 
 export {
@@ -13,4 +14,5 @@ export {
   clearCommand,
   detectFrameworkCommand,
   analyzeCommand,
+  planCommand,
 };

--- a/packages/shortest/src/cli/commands/plan.ts
+++ b/packages/shortest/src/cli/commands/plan.ts
@@ -1,0 +1,58 @@
+import { Command, Option } from "commander";
+import { executeCommand } from "@/cli/utils/command-builder";
+import { SUPPORTED_FRAMEWORKS } from "@/core/app-analyzer";
+import { getProjectInfo } from "@/core/framework-detector";
+import { TestPlanner } from "@/core/test-planner";
+import { getLogger } from "@/log";
+import { LOG_LEVELS } from "@/log/config";
+import { ShortestError } from "@/utils/errors";
+
+export const planCommand = new Command("plan").description(
+  "Generate test plans from app analysis",
+);
+
+planCommand
+  .addOption(
+    new Option("--log-level <level>", "Set logging level").choices(LOG_LEVELS),
+  )
+  .addOption(
+    new Option(
+      "--force",
+      "Force plan generation even if cached data exists",
+    ).default(false),
+  )
+  .action(async function () {
+    await executeCommand(this.name(), this.optsWithGlobals(), async () =>
+      executePlanCommand(this.opts()),
+    );
+  })
+  .showHelpAfterError("(add --help for additional information)");
+
+const executePlanCommand = async (
+  options: { force?: boolean } = {},
+): Promise<void> => {
+  const log = getLogger();
+  const cwd = process.cwd();
+  const projectInfo = await getProjectInfo();
+  const supportedFrameworks = projectInfo.data.frameworks.filter((f) =>
+    SUPPORTED_FRAMEWORKS.includes(f.id),
+  );
+
+  if (supportedFrameworks.length === 0) {
+    throw new ShortestError(`No supported framework found`);
+  }
+
+  if (supportedFrameworks.length > 1) {
+    throw new ShortestError(
+      `Multiple supported frameworks found: ${supportedFrameworks.map((f) => f.name).join(", ")}`,
+    );
+  }
+
+  const framework = supportedFrameworks[0].id;
+  log.info(`Generating test plans for ${framework} application...`);
+
+  const planner = new TestPlanner(cwd, framework);
+  const testPlans = await planner.execute(options);
+
+  log.info(`Test planning complete. Generated ${testPlans.length} test plans.`);
+};

--- a/packages/shortest/src/cli/commands/plan.ts
+++ b/packages/shortest/src/cli/commands/plan.ts
@@ -48,10 +48,10 @@ const executePlanCommand = async (
     );
   }
 
-  const framework = supportedFrameworks[0].id;
-  log.info(`Generating test plans for ${framework} application...`);
+  const framework = supportedFrameworks[0];
+  log.info(`Generating test plans for ${framework.name} application...`);
 
-  const planner = new TestPlanner(cwd, framework);
+  const planner = new TestPlanner(cwd, framework.id);
   const testPlans = await planner.execute(options);
 
   log.info(`Test planning complete. Generated ${testPlans.length} test plans.`);

--- a/packages/shortest/src/core/test-planner/index.ts
+++ b/packages/shortest/src/core/test-planner/index.ts
@@ -14,8 +14,12 @@ import { getGitInfo, GitInfo } from "@/utils/get-git-info";
 const TestPlanSchema = z.object({
   testPlans: z.array(
     z.object({
-      steps: z.array(z.string()),
-      requiresAuth: z.boolean(),
+      steps: z.array(
+        z.object({
+          statement: z.string(),
+          requiresAuth: z.boolean().optional(),
+        }),
+      ),
     }),
   ),
 });
@@ -35,6 +39,8 @@ export interface TestPlanInfo {
 }
 
 export class TestPlanner {
+  public static readonly TEST_PLAN_FILE_NAME = "test-plan.json";
+
   private rootDir: string;
   private framework: string;
   private log = getLogger();
@@ -68,7 +74,10 @@ export class TestPlanner {
   private async getExistingTestPlans(): Promise<TestPlanInfo | null> {
     try {
       const frameworkDir = path.join(DOT_SHORTEST_DIR_PATH, this.framework);
-      const testPlanJsonPath = path.join(frameworkDir, "test-plan.json");
+      const testPlanJsonPath = path.join(
+        frameworkDir,
+        TestPlanner.TEST_PLAN_FILE_NAME,
+      );
 
       try {
         await fs.access(testPlanJsonPath);

--- a/packages/shortest/src/core/test-planner/index.ts
+++ b/packages/shortest/src/core/test-planner/index.ts
@@ -88,12 +88,13 @@ export class TestPlanner {
   }
 
   private async createTestPlans(): Promise<TestPlan[]> {
-    this.log.trace("Creating test plan...");
     await initializeConfig({});
 
     const analysis = await getExistingAnalysis(this.framework);
 
     const model = createProvider(getConfig().ai);
+
+    this.log.trace("Making AI request to generate test plans");
     const resp = await generateText({
       system: SYSTEM_PROMPT,
       model,

--- a/packages/shortest/src/core/test-planner/index.ts
+++ b/packages/shortest/src/core/test-planner/index.ts
@@ -1,0 +1,137 @@
+import fs from "fs/promises";
+import path from "path";
+import { generateText } from "ai";
+import { z } from "zod";
+import { SYSTEM_PROMPT } from "./system-prompt";
+import { createProvider } from "@/ai/provider";
+import { DOT_SHORTEST_DIR_PATH } from "@/cache";
+import { getExistingAnalysis } from "@/core/app-analyzer";
+import { getConfig, initializeConfig } from "@/index";
+import { getLogger } from "@/log";
+import { getErrorDetails } from "@/utils/errors";
+import { getGitInfo, GitInfo } from "@/utils/get-git-info";
+
+const TestPlanSchema = z.object({
+  testPlans: z.array(
+    z.object({
+      steps: z.array(z.string()),
+      requiresAuth: z.boolean(),
+    }),
+  ),
+});
+
+// eslint-disable-next-line zod/require-zod-schema-types
+export type TestPlan = z.infer<typeof TestPlanSchema>["testPlans"][number];
+
+export interface TestPlanInfo {
+  metadata: {
+    timestamp: number;
+    version: number;
+    git: GitInfo;
+  };
+  data: {
+    testPlans: TestPlan[];
+  };
+}
+
+export class TestPlanner {
+  private rootDir: string;
+  private framework: string;
+  private log = getLogger();
+
+  private readonly TEST_PLAN_VERSION = 1;
+  private readonly frameworkDir: string;
+
+  constructor(rootDir: string, framework: string) {
+    this.rootDir = rootDir;
+    this.framework = framework;
+    this.frameworkDir = path.join(DOT_SHORTEST_DIR_PATH, this.framework);
+  }
+
+  public async execute(options: { force?: boolean } = {}): Promise<TestPlan[]> {
+    this.log.trace("Executing test plan...", { framework: this.framework });
+
+    if (!options.force) {
+      const existingTestPlanInfo = await this.getExistingTestPlans();
+      if (existingTestPlanInfo) {
+        this.log.trace("Using existing test plan from cache");
+        return existingTestPlanInfo.data.testPlans;
+      }
+    }
+
+    const testPlans = await this.createTestPlans();
+    await this.saveTestPlansToFile(testPlans);
+
+    return testPlans;
+  }
+
+  private async getExistingTestPlans(): Promise<TestPlanInfo | null> {
+    try {
+      const frameworkDir = path.join(DOT_SHORTEST_DIR_PATH, this.framework);
+      const testPlanJsonPath = path.join(frameworkDir, "test-plan.json");
+
+      try {
+        await fs.access(testPlanJsonPath);
+      } catch {
+        return null;
+      }
+
+      const testPlanJson = await fs.readFile(testPlanJsonPath, "utf-8");
+      return JSON.parse(testPlanJson);
+    } catch (error) {
+      this.log.trace(
+        "Failed to read existing analysis",
+        getErrorDetails(error),
+      );
+      return null;
+    }
+  }
+
+  private async createTestPlans(): Promise<TestPlan[]> {
+    this.log.trace("Creating test plan...");
+    await initializeConfig({});
+
+    const analysis = await getExistingAnalysis(this.framework);
+
+    const model = createProvider(getConfig().ai);
+    const resp = await generateText({
+      system: SYSTEM_PROMPT,
+      model,
+      prompt: `Generate a test plan for the attached analysis: ${JSON.stringify(
+        analysis,
+      )}`,
+    });
+
+    const rawTestPlans = JSON.parse(resp.text);
+    const testPlans = TestPlanSchema.parse(rawTestPlans).testPlans;
+
+    return testPlans;
+  }
+
+  private async saveTestPlansToFile(testPlans: TestPlan[]): Promise<void> {
+    try {
+      await fs.mkdir(this.frameworkDir, { recursive: true });
+      const testPlanJsonPath = path.join(this.frameworkDir, "test-plan.json");
+
+      const output = {
+        metadata: {
+          timestamp: Date.now(),
+          version: this.TEST_PLAN_VERSION,
+          git: await getGitInfo(),
+        },
+        data: {
+          testPlans,
+        },
+      };
+
+      await fs.writeFile(testPlanJsonPath, JSON.stringify(output, null, 2));
+      this.log.trace(`Test plan saved to ${testPlanJsonPath}`);
+    } catch (error) {
+      this.log.error(
+        "Failed to save test plans to file",
+        getErrorDetails(error),
+      );
+      throw error;
+    }
+  }
+}

--- a/packages/shortest/src/core/test-planner/system-prompt.ts
+++ b/packages/shortest/src/core/test-planner/system-prompt.ts
@@ -1,0 +1,29 @@
+export const SYSTEM_PROMPT = `You are an expert test architect specializing in writing end-to-end testing plans. Your role is to:
+
+1. Analyze the provided application structure
+2. Create a testing plan that covers the main functional flows, up to 10 plans
+3. Write each test plan in natural language, similar to how a user would interact with the application
+
+For each test plan, include the following:
+- The steps to reproduce the test plan, not more than 5 steps. If more than 5 steps are needed, split into multiple test plans.
+- Each step should be a natural language description of the action to be taken, not more than 10 words.
+- Each step is the expected outcome of that step
+
+**Format output**
+Return a JSON object with the following fields:
+- testPlans: An array of test plans
+Each test plan should have the following fields:
+- steps: An array of steps (simple sentences, not more than 10 words each)
+- requiresAuth: A boolean indicating if the test plan requires authentication
+
+The final response MUST return only the JSON object, nothing else.
+
+**Other rules**
+- Do not use component names to navigate to a certain page, as those are not visible to the user.
+- Do not add instructions to navigate to a certain URL. Instead, If the user need to navigate to a certain page, use UI element names (or generic names) to navigate to it.
+
+If a given test plan requires authentication, include the step to log in.
+
+For context, the test plans will be converted into tests using a testing framework called Shortest, based on Playwright. The tests will be executed using a computer use agent that will navigate the application and interact with it.
+
+The application is using Next.js 15 framework. Leverage this knowledge to write the test plans.`;

--- a/packages/shortest/src/core/test-planner/system-prompt.ts
+++ b/packages/shortest/src/core/test-planner/system-prompt.ts
@@ -12,9 +12,11 @@ For each test plan, include the following:
 **Format output**
 Return a JSON object with the following fields:
 - testPlans: An array of test plans
-Each test plan should have the following fields:
-- steps: An array of steps (simple sentences, not more than 10 words each)
-- requiresAuth: A boolean indicating if the test plan requires authentication
+Each test plan must have the following fields:
+- steps: An array of steps
+Each step must be an object with the following fields:
+- step.statement: A string representing the step (simple sentence, not more than 10 words)
+- step.requiresAuth: Optional, only one step must have this set to true within a given test plan. A boolean indicating if the step requires authentication.
 
 The final response MUST return only the JSON object, nothing else.
 


### PR DESCRIPTION
> [!NOTE]
> Experimental feature

Follow-up on https://github.com/antiwork/shortest/pull/402

New command `npx shortest plan`

Generates `.shortest/{framework}/test-plan.json`. Uses AI to generate up to 10 test plans based on the `analysis.json` file

Sample [test-plan.json](https://gist.github.com/rmarescu/3457f144757875456d34af417a66468a)
