### PR TITLE
feat: add sample test file generation to init command

### DIFF
--- a/packages/shortest/package.json
+++ b/packages/shortest/package.json
@@ -43,6 +43,8 @@
     "@babel/parser": "^7.26.9",
     "@babel/traverse": "^7.26.9",
     "@babel/types": "^7.26.9",
+    "@inquirer/prompts": "^7.4.0",
+    "@listr2/prompt-adapter-inquirer": "^2.0.18",
     "@netlify/framework-info": "^9.9.2",
     "@types/babel__traverse": "^7.20.6",
     "chromium-bidi": "^0.5.24",

--- a/packages/shortest/scripts/build-cli.js
+++ b/packages/shortest/scripts/build-cli.js
@@ -12,7 +12,7 @@ const externalDeps = [
   "esbuild", "playwright", "expect", "dotenv", "otplib", "picocolors",
   "punycode", "mailosaur", "ai", "@ai-sdk/*", "@babel/*", "commander",
   "@netlify/framework-info", "normalize-package-data", "hosted-git-info", "glob",
-  "simple-git", "globby", "listr2"
+  "simple-git", "globby", "listr2", "@inquirer/prompts", "@listr2/prompt-adapter-inquirer"
 ];
 
 const cmd = [

--- a/packages/shortest/src/cli/commands/analyze.ts
+++ b/packages/shortest/src/cli/commands/analyze.ts
@@ -1,10 +1,8 @@
 import { Command, Option } from "commander";
 import { executeCommand } from "@/cli/utils/command-builder";
-import { AppAnalyzer, SUPPORTED_FRAMEWORKS } from "@/core/app-analyzer";
-import { getProjectInfo } from "@/core/framework-detector";
+import { AppAnalyzer, detectSupportedFramework } from "@/core/app-analyzer";
 import { getLogger } from "@/log";
 import { LOG_LEVELS } from "@/log/config";
-import { ShortestError } from "@/utils/errors";
 
 export const analyzeCommand = new Command("analyze").description(
   "Analyze the structure of the project",
@@ -31,26 +29,10 @@ const executeAnalyzeCommand = async (
 ): Promise<void> => {
   const log = getLogger();
   const cwd = process.cwd();
-  const projectInfo = await getProjectInfo();
-  const supportedFrameworks = projectInfo.data.frameworks.filter((f) =>
-    SUPPORTED_FRAMEWORKS.includes(f.id),
-  );
+  const supportedFramework = await detectSupportedFramework();
+  log.info(`Analyzing ${supportedFramework} application structure...`);
 
-  if (supportedFrameworks.length === 0) {
-    throw new ShortestError(`No supported framework found`);
-  }
-
-  if (supportedFrameworks.length > 1) {
-    throw new ShortestError(
-      `Multiple supported frameworks found: ${supportedFrameworks.map((f) => f.name).join(", ")}`,
-    );
-  }
-
-  const framework = supportedFrameworks[0].id;
-
-  log.info(`Analyzing ${framework} application structure...`);
-
-  const analyzer = new AppAnalyzer(cwd, framework);
+  const analyzer = new AppAnalyzer(cwd, supportedFramework);
   const analysis = await analyzer.execute(options);
 
   log.info(

--- a/packages/shortest/src/cli/commands/analyze.ts
+++ b/packages/shortest/src/cli/commands/analyze.ts
@@ -28,11 +28,10 @@ const executeAnalyzeCommand = async (
   options: { force?: boolean } = {},
 ): Promise<void> => {
   const log = getLogger();
-  const cwd = process.cwd();
-  const supportedFramework = await detectSupportedFramework();
-  log.info(`Analyzing ${supportedFramework} application structure...`);
+  const supportedFrameworkInfo = await detectSupportedFramework();
+  log.info(`Analyzing ${supportedFrameworkInfo.name} application structure...`);
 
-  const analyzer = new AppAnalyzer(cwd, supportedFramework);
+  const analyzer = new AppAnalyzer(supportedFrameworkInfo);
   const analysis = await analyzer.execute(options);
 
   log.info(

--- a/packages/shortest/src/cli/commands/generate.ts
+++ b/packages/shortest/src/cli/commands/generate.ts
@@ -1,11 +1,9 @@
 import { Command, Option } from "commander";
 import { executeCommand } from "@/cli/utils/command-builder";
-import { SUPPORTED_FRAMEWORKS } from "@/core/app-analyzer";
-import { getProjectInfo } from "@/core/framework-detector";
+import { detectSupportedFramework } from "@/core/app-analyzer";
 import { TestGenerator } from "@/core/test-generator";
 import { getLogger } from "@/log";
 import { LOG_LEVELS } from "@/log/config";
-import { ShortestError } from "@/utils/errors";
 
 export const generateCommand = new Command("generate").description(
   "Generate tests from test plans",
@@ -33,25 +31,10 @@ const executeGenerateCommand = async (
 ): Promise<void> => {
   const log = getLogger();
   const cwd = process.cwd();
-  const projectInfo = await getProjectInfo();
-  const supportedFrameworks = projectInfo.data.frameworks.filter((f) =>
-    SUPPORTED_FRAMEWORKS.includes(f.id),
-  );
+  const supportedFramework = await detectSupportedFramework();
+  log.info(`Generating tests...`);
 
-  if (supportedFrameworks.length === 0) {
-    throw new ShortestError(`No supported framework found`);
-  }
-
-  if (supportedFrameworks.length > 1) {
-    throw new ShortestError(
-      `Multiple supported frameworks found: ${supportedFrameworks.map((f) => f.name).join(", ")}`,
-    );
-  }
-
-  const framework = supportedFrameworks[0];
-  log.info(`Generating tests for ${framework.name} application...`);
-
-  const generator = new TestGenerator(cwd, framework.id);
+  const generator = new TestGenerator(cwd, supportedFramework);
   await generator.execute(options);
 
   log.info(`Test generation complete.`);

--- a/packages/shortest/src/cli/commands/generate.ts
+++ b/packages/shortest/src/cli/commands/generate.ts
@@ -31,10 +31,10 @@ const executeGenerateCommand = async (
 ): Promise<void> => {
   const log = getLogger();
   const cwd = process.cwd();
-  const supportedFramework = await detectSupportedFramework();
+  const supportedFrameworkInfo = await detectSupportedFramework();
   log.info(`Generating tests...`);
 
-  const generator = new TestGenerator(cwd, supportedFramework);
+  const generator = new TestGenerator(cwd, supportedFrameworkInfo);
   await generator.execute(options);
 
   log.info(`Test generation complete.`);

--- a/packages/shortest/src/cli/commands/init.ts
+++ b/packages/shortest/src/cli/commands/init.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import { Writable } from "node:stream";
 import { join } from "path";
 import type { Readable } from "stream";
-import { select, input, confirm } from "@inquirer/prompts";
+import { select, input, confirm, password } from "@inquirer/prompts";
 import { ListrInquirerPromptAdapter } from "@listr2/prompt-adapter-inquirer";
 import { Command, Option } from "commander";
 import {
@@ -187,9 +187,9 @@ export const executeInitCommand = async () => {
                                 task: async (ctx, task) =>
                                   (ctx.anthropicApiKeyValue = await task
                                     .prompt(ListrInquirerPromptAdapter)
-                                    .run(input, {
+                                    .run(password, {
                                       message: `Enter value for ${ctx.anthropicApiKeyName}`,
-                                      required: true,
+                                      mask: true,
                                     })),
                               },
                               {

--- a/packages/shortest/src/cli/commands/init/generate-config-file.ts
+++ b/packages/shortest/src/cli/commands/init/generate-config-file.ts
@@ -1,0 +1,52 @@
+import { createRequire } from "module";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import * as t from "@babel/types";
+import { CONFIG_FILENAME } from "@/constants";
+import { formatCode } from "@/core/test-generator/utils/format-code";
+import { lintCode } from "@/core/test-generator/utils/lint-code";
+
+const require = createRequire(import.meta.url);
+const generate = require("@babel/generator").default;
+const parser = require("@babel/parser");
+const traverse = require("@babel/traverse").default;
+
+export const generateConfigFile = async (
+  filePath: string,
+  configOptions: { testPattern?: string },
+) => {
+  const exampleFileDir = fileURLToPath(new URL("../../src", import.meta.url));
+  const exampleConfigPath = join(exampleFileDir, `${CONFIG_FILENAME}.example`);
+
+  const exampleConfigContent = await readFile(exampleConfigPath, "utf8");
+
+  const ast = parser.parse(exampleConfigContent, {
+    sourceType: "module",
+    plugins: ["typescript"],
+  });
+
+  if (configOptions.testPattern) {
+    const testPattern = configOptions.testPattern;
+    traverse(ast, {
+      ObjectProperty(path: any) {
+        if (
+          t.isIdentifier(path.node.key) &&
+          path.node.key.name === "testPattern"
+        ) {
+          path.node.value = t.stringLiteral(testPattern);
+        }
+      },
+    });
+  }
+
+  const modifiedContent = generate(ast, {
+    retainLines: true,
+    compact: false,
+  }).code;
+
+  const formattedCode = await formatCode(modifiedContent, process.cwd());
+  const lintedCode = await lintCode(formattedCode, process.cwd());
+
+  await writeFile(filePath, lintedCode, "utf8");
+};

--- a/packages/shortest/src/cli/commands/plan.ts
+++ b/packages/shortest/src/cli/commands/plan.ts
@@ -1,11 +1,9 @@
 import { Command, Option } from "commander";
 import { executeCommand } from "@/cli/utils/command-builder";
-import { SUPPORTED_FRAMEWORKS } from "@/core/app-analyzer";
-import { getProjectInfo } from "@/core/framework-detector";
+import { detectSupportedFramework } from "@/core/app-analyzer";
 import { TestPlanner } from "@/core/test-planner";
 import { getLogger } from "@/log";
 import { LOG_LEVELS } from "@/log/config";
-import { ShortestError } from "@/utils/errors";
 
 export const planCommand = new Command("plan").description(
   "Generate test plans from app analysis",
@@ -33,25 +31,10 @@ const executePlanCommand = async (
 ): Promise<void> => {
   const log = getLogger();
   const cwd = process.cwd();
-  const projectInfo = await getProjectInfo();
-  const supportedFrameworks = projectInfo.data.frameworks.filter((f) =>
-    SUPPORTED_FRAMEWORKS.includes(f.id),
-  );
+  const supportedFramework = await detectSupportedFramework();
+  log.info(`Generating test plans...`);
 
-  if (supportedFrameworks.length === 0) {
-    throw new ShortestError(`No supported framework found`);
-  }
-
-  if (supportedFrameworks.length > 1) {
-    throw new ShortestError(
-      `Multiple supported frameworks found: ${supportedFrameworks.map((f) => f.name).join(", ")}`,
-    );
-  }
-
-  const framework = supportedFrameworks[0];
-  log.info(`Generating test plans for ${framework.name} application...`);
-
-  const planner = new TestPlanner(cwd, framework.id);
+  const planner = new TestPlanner(cwd, supportedFramework);
   const testPlans = await planner.execute(options);
 
   log.info(`Test planning complete. Generated ${testPlans.length} test plans.`);

--- a/packages/shortest/src/cli/commands/plan.ts
+++ b/packages/shortest/src/cli/commands/plan.ts
@@ -30,11 +30,10 @@ const executePlanCommand = async (
   options: { force?: boolean } = {},
 ): Promise<void> => {
   const log = getLogger();
-  const cwd = process.cwd();
-  const supportedFramework = await detectSupportedFramework();
+  const supportedFrameworkInfo = await detectSupportedFramework();
   log.info(`Generating test plans...`);
 
-  const planner = new TestPlanner(cwd, supportedFramework);
+  const planner = new TestPlanner(supportedFrameworkInfo);
   const testPlans = await planner.execute(options);
 
   log.info(`Test planning complete. Generated ${testPlans.length} test plans.`);

--- a/packages/shortest/src/core/app-analyzer/index.ts
+++ b/packages/shortest/src/core/app-analyzer/index.ts
@@ -4,12 +4,13 @@ import path from "path";
 import { DOT_SHORTEST_DIR_PATH } from "@/cache";
 import { NextJsAnalyzer } from "@/core/app-analyzer/next-js-analyzer";
 import { AppAnalysis } from "@/core/app-analyzer/types";
+import { getProjectInfo } from "@/core/framework-detector";
 import { getLogger } from "@/log";
 import { ShortestError, getErrorDetails } from "@/utils/errors";
 
 export const SUPPORTED_FRAMEWORKS = ["next"];
 // eslint-disable-next-line zod/require-zod-schema-types
-type SupportedFramework = (typeof SUPPORTED_FRAMEWORKS)[number];
+export type SupportedFramework = (typeof SUPPORTED_FRAMEWORKS)[number];
 
 export class AppAnalyzer {
   private rootDir: string;
@@ -92,3 +93,23 @@ export const getExistingAnalysis = async (
     return null;
   }
 };
+
+export const detectSupportedFramework =
+  async (): Promise<SupportedFramework> => {
+    const projectInfo = await getProjectInfo();
+    const supportedFrameworks = projectInfo.data.frameworks.filter((f) =>
+      SUPPORTED_FRAMEWORKS.includes(f.id),
+    );
+
+    if (supportedFrameworks.length === 0) {
+      throw new ShortestError(`No supported framework found`);
+    }
+
+    if (supportedFrameworks.length > 1) {
+      throw new ShortestError(
+        `Multiple supported frameworks found: ${supportedFrameworks.map((f) => f.name).join(", ")}`,
+      );
+    }
+
+    return supportedFrameworks[0].id;
+  };

--- a/packages/shortest/src/core/app-analyzer/index.ts
+++ b/packages/shortest/src/core/app-analyzer/index.ts
@@ -8,44 +8,54 @@ import { getProjectInfo } from "@/core/framework-detector";
 import { getLogger } from "@/log";
 import { ShortestError, getErrorDetails } from "@/utils/errors";
 
-export const SUPPORTED_FRAMEWORKS = ["next"];
+export interface FrameworkInfo {
+  id: string;
+  name: string;
+  dirPath: string;
+}
+
+export const SUPPORTED_FRAMEWORKS_IDS = ["next"];
 // eslint-disable-next-line zod/require-zod-schema-types
-export type SupportedFramework = (typeof SUPPORTED_FRAMEWORKS)[number];
+export type SupportedFrameworkId = (typeof SUPPORTED_FRAMEWORKS_IDS)[number];
 
 export class AppAnalyzer {
-  private rootDir: string;
-  private framework: SupportedFramework;
-  private log = getLogger();
+  private readonly frameworkInfo: FrameworkInfo;
+  private readonly log = getLogger();
 
-  constructor(rootDir: string, framework: SupportedFramework) {
-    this.rootDir = rootDir;
-    this.framework = framework;
+  constructor(frameworkInfo: FrameworkInfo) {
+    this.frameworkInfo = frameworkInfo;
   }
 
   public async execute(
     options: { force?: boolean } = {},
   ): Promise<AppAnalysis> {
-    this.log.trace("Analyzing application...", { framework: this.framework });
+    this.log.trace("Analyzing application...", {
+      framework: this.frameworkInfo.id,
+    });
 
     let analysis: AppAnalysis;
 
     if (!options.force) {
-      const existingAnalysis = await getExistingAnalysis(this.framework);
+      const existingAnalysis = await getExistingAnalysis(this.frameworkInfo.id);
       if (existingAnalysis) {
         this.log.trace("Using existing analysis from cache");
         return existingAnalysis;
       }
     }
 
-    switch (this.framework) {
+    switch (this.frameworkInfo.id) {
       case "next":
         analysis = await this.analyzeNextJs();
         break;
       default:
-        throw new ShortestError(`Unsupported framework: ${this.framework}`);
+        throw new ShortestError(
+          `Unsupported framework: ${this.frameworkInfo.id}`,
+        );
     }
 
-    this.log.trace(`Analysis complete for ${this.framework} framework`);
+    this.log.trace(
+      `Analysis complete for ${this.frameworkInfo.name} framework`,
+    );
     return analysis;
   }
 
@@ -53,7 +63,7 @@ export class AppAnalyzer {
     this.log.trace("Starting Next.js analysis");
 
     try {
-      const nextAnalyzer = new NextJsAnalyzer(this.rootDir);
+      const nextAnalyzer = new NextJsAnalyzer(this.frameworkInfo);
       const analysis = await nextAnalyzer.execute();
 
       this.log.trace("Next.js analysis completed successfully");
@@ -69,14 +79,14 @@ export class AppAnalyzer {
 }
 
 export const getExistingAnalysis = async (
-  framework: SupportedFramework,
+  frameworkId: SupportedFrameworkId,
 ): Promise<AppAnalysis | null> => {
   const log = getLogger();
-  log.trace("Getting existing analysis", { framework });
+  log.trace("Getting existing analysis", { frameworkId });
 
   try {
-    const frameworkDir = path.join(DOT_SHORTEST_DIR_PATH, framework);
-    const analysisJsonPath = path.join(frameworkDir, "analysis.json");
+    const cacheFrameworkDir = path.join(DOT_SHORTEST_DIR_PATH, frameworkId);
+    const analysisJsonPath = path.join(cacheFrameworkDir, "analysis.json");
 
     try {
       await fs.access(analysisJsonPath);
@@ -94,22 +104,21 @@ export const getExistingAnalysis = async (
   }
 };
 
-export const detectSupportedFramework =
-  async (): Promise<SupportedFramework> => {
-    const projectInfo = await getProjectInfo();
-    const supportedFrameworks = projectInfo.data.frameworks.filter((f) =>
-      SUPPORTED_FRAMEWORKS.includes(f.id),
+export const detectSupportedFramework = async (): Promise<FrameworkInfo> => {
+  const projectInfo = await getProjectInfo();
+  const supportedFrameworks = projectInfo.data.frameworks.filter((f) =>
+    SUPPORTED_FRAMEWORKS_IDS.includes(f.id),
+  );
+
+  if (supportedFrameworks.length === 0) {
+    throw new ShortestError(`No supported framework found`);
+  }
+
+  if (supportedFrameworks.length > 1) {
+    throw new ShortestError(
+      `Multiple supported frameworks found: ${supportedFrameworks.map((f) => f.name).join(", ")}`,
     );
+  }
 
-    if (supportedFrameworks.length === 0) {
-      throw new ShortestError(`No supported framework found`);
-    }
-
-    if (supportedFrameworks.length > 1) {
-      throw new ShortestError(
-        `Multiple supported frameworks found: ${supportedFrameworks.map((f) => f.name).join(", ")}`,
-      );
-    }
-
-    return supportedFrameworks[0].id;
-  };
+  return supportedFrameworks[0];
+};

--- a/packages/shortest/src/core/app-analyzer/types.ts
+++ b/packages/shortest/src/core/app-analyzer/types.ts
@@ -1,3 +1,5 @@
+import { FrameworkInfo } from "@/core/app-analyzer";
+
 /**
  * Base analyzer interface that all framework-specific analyzers must implement
  */
@@ -12,7 +14,7 @@ export interface FileAnalysisResult {
 }
 
 export interface AppAnalysis {
-  framework: string;
+  framework: FrameworkInfo;
   routerType: "app" | "pages" | "unknown";
   stats: {
     fileCount: number;

--- a/packages/shortest/src/core/framework-detector/index.ts
+++ b/packages/shortest/src/core/framework-detector/index.ts
@@ -4,6 +4,8 @@ import path from "path";
 import { listFrameworks } from "@netlify/framework-info";
 import { Framework } from "@netlify/framework-info/lib/types";
 import { DOT_SHORTEST_DIR_PATH } from "@/cache";
+import { getPackageJson } from "@/cli/commands/init";
+import { FrameworkInfo } from "@/core/app-analyzer";
 import { getLogger } from "@/log";
 import { getErrorDetails, ShortestError } from "@/utils/errors";
 import { getGitInfo, GitInfo } from "@/utils/get-git-info";
@@ -15,7 +17,7 @@ export interface ProjectInfo {
     git: GitInfo;
   };
   data: {
-    frameworks: Framework[];
+    frameworks: FrameworkInfo[];
   };
 }
 
@@ -23,6 +25,38 @@ export const PROJECT_JSON_PATH = path.join(
   DOT_SHORTEST_DIR_PATH,
   "project.json",
 );
+
+const detectNextJsPathFromPackageJson = (
+  packageJson: any,
+): string | undefined => {
+  if (!packageJson) return undefined;
+
+  if (packageJson.workspaces) {
+    // Find any workspace that contains 'next'
+    const nextWorkspace = packageJson.workspaces.find((workspace: string) =>
+      workspace.includes("next"),
+    );
+
+    if (nextWorkspace) {
+      // Handle pattern with wildcards
+      if (nextWorkspace.endsWith("/*")) {
+        const basePath = nextWorkspace.replace("/*", "");
+        // Try to find the most specific path - prefer 'nextjs' over just 'next'
+        return path.join(process.cwd(), `${basePath}/nextjs`);
+      }
+
+      // Use the exact workspace path found
+      return path.join(process.cwd(), nextWorkspace);
+    }
+  }
+
+  return undefined;
+};
+
+const detectNextJsPathFromConfig = async (): Promise<FrameworkInfo | undefined> => {
+  const paths = await getPaths(process.cwd());
+
+};
 
 export const getProjectInfo = async (): Promise<ProjectInfo> => {
   const log = getLogger();
@@ -54,12 +88,37 @@ export const detectFramework = async (options: { force?: boolean } = {}) => {
     }
   }
 
-  const frameworks = await listFrameworks({ projectDir: process.cwd() });
+  let frameworks: Framework[] = [];
+  let frameworkInfos: FrameworkInfo[] = [];
+
+  frameworks = await listFrameworks({ projectDir: process.cwd() });
+  frameworks.map((framework) => {
+    frameworkInfos.push({
+      id: framework.id,
+      name: framework.name,
+      dirPath: process.cwd(),
+    });
+  });
+
+  if (frameworks.length === 0) {
+    const packageJson = await getPackageJson();
+    const possibleNextJsPath = detectNextJsPathFromPackageJson(packageJson);
+    if (possibleNextJsPath) {
+      frameworks = await listFrameworks({ projectDir: possibleNextJsPath });
+      frameworks.map((framework) => {
+        frameworkInfos.push({
+          id: framework.id,
+          name: framework.name,
+          dirPath: possibleNextJsPath,
+        });
+      });
+    }
+  }
 
   await fs.mkdir(DOT_SHORTEST_DIR_PATH, { recursive: true });
 
   try {
-    const VERSION = 1;
+    const VERSION = 2;
 
     const projectInfo = {
       metadata: {
@@ -68,7 +127,7 @@ export const detectFramework = async (options: { force?: boolean } = {}) => {
         git: await getGitInfo(),
       },
       data: {
-        frameworks,
+        frameworks: frameworkInfos,
       },
     };
 

--- a/packages/shortest/src/core/test-generator/index.ts
+++ b/packages/shortest/src/core/test-generator/index.ts
@@ -62,8 +62,14 @@ export class TestGenerator {
 
   private async generateTestFile(): Promise<void> {
     const rawFileContent = await this.generateRawFileOutput();
-    const formattedCode = await formatCode(rawFileContent, this.rootDir);
-    const lintedCode = await lintCode(formattedCode, this.rootDir);
+    const formattedCode = await formatCode(
+      rawFileContent,
+      this.frameworkInfo.dirPath,
+    );
+    const lintedCode = await lintCode(
+      formattedCode,
+      this.frameworkInfo.dirPath,
+    );
 
     try {
       await fs.mkdir(SHORTEST_DIR_PATH, { recursive: true });

--- a/packages/shortest/src/core/test-generator/index.ts
+++ b/packages/shortest/src/core/test-generator/index.ts
@@ -2,11 +2,12 @@ import fs from "fs/promises";
 import { createRequire } from "module";
 import path from "path";
 import * as t from "@babel/types";
-import { TestPlan, TestPlanner } from "../test-planner";
 import { DOT_SHORTEST_DIR_PATH } from "@/cache";
 import { SHORTEST_NAME } from "@/cli/commands/shortest";
+import { FrameworkInfo } from "@/core/app-analyzer";
 import { formatCode } from "@/core/test-generator/utils/format-code";
 import { lintCode } from "@/core/test-generator/utils/lint-code";
+import { TestPlan, TestPlanner } from "@/core/test-planner";
 import { getLogger } from "@/log";
 import { getErrorDetails } from "@/utils/errors";
 
@@ -18,23 +19,25 @@ const require = createRequire(import.meta.url);
 const generate = require("@babel/generator").default;
 
 export class TestGenerator {
-  private rootDir: string;
-  private framework: string;
-  private log = getLogger();
-
+  private readonly rootDir: string;
+  private readonly frameworkInfo: FrameworkInfo;
+  private readonly log = getLogger();
   private readonly outputPath: string;
   private readonly TEST_FILE_NAME = "functional.test.ts";
-  private readonly frameworkDir: string;
+  private readonly cacheFrameworkDir: string;
 
-  constructor(rootDir: string, framework: string) {
+  constructor(rootDir: string, frameworkInfo: FrameworkInfo) {
     this.rootDir = rootDir;
-    this.framework = framework;
-    this.frameworkDir = path.join(DOT_SHORTEST_DIR_PATH, this.framework);
+    this.frameworkInfo = frameworkInfo;
+    this.cacheFrameworkDir = path.join(
+      DOT_SHORTEST_DIR_PATH,
+      this.frameworkInfo.id,
+    );
     this.outputPath = path.join(SHORTEST_DIR_PATH, this.TEST_FILE_NAME);
   }
 
   public async execute(options: { force?: boolean } = {}): Promise<void> {
-    this.log.trace("Generating tests...", { framework: this.framework });
+    this.log.trace("Generating tests...", { framework: this.frameworkInfo });
 
     if (!options.force) {
       if (await this.testFileExists()) {
@@ -148,7 +151,7 @@ export class TestGenerator {
 
   private async getTestPlans(): Promise<TestPlan[]> {
     const testPlanJsonPath = path.join(
-      this.frameworkDir,
+      this.cacheFrameworkDir,
       TestPlanner.TEST_PLAN_FILE_NAME,
     );
     const testPlanJson = await fs.readFile(testPlanJsonPath, "utf-8");

--- a/packages/shortest/src/core/test-generator/utils/lint-code.ts
+++ b/packages/shortest/src/core/test-generator/utils/lint-code.ts
@@ -16,6 +16,7 @@ export const lintCode = async (
     const eslintPath = require.resolve("eslint", {
       paths: [rootDir],
     });
+    log.trace("ESLint path", { eslintPath });
     const { ESLint } = await import(eslintPath);
 
     const customConfig = {

--- a/packages/shortest/src/types/config.ts
+++ b/packages/shortest/src/types/config.ts
@@ -53,7 +53,7 @@ const mailosaurSchema = z
   })
   .optional();
 
-const testPatternSchema = z.string().default("**/*.test.ts");
+export const testPatternSchema = z.string().default("**/*.test.ts");
 
 const browserSchema = z.object({
   /**

--- a/packages/shortest/src/utils/env-file.ts
+++ b/packages/shortest/src/utils/env-file.ts
@@ -49,6 +49,10 @@ export class EnvFile {
     return existsSync(this.filePath);
   }
 
+  keyExists(key: string): boolean {
+    return this._existingEntries.has(key);
+  }
+
   async add(entry: {
     key: string;
     value: string;
@@ -60,7 +64,7 @@ export class EnvFile {
 
     const { key, value, comment } = entry;
 
-    if (this._existingEntries.has(key)) {
+    if (this.keyExists(key)) {
       this._keysSkipped.push(key);
       return false;
     }

--- a/packages/shortest/src/utils/get-git-info.ts
+++ b/packages/shortest/src/utils/get-git-info.ts
@@ -1,4 +1,4 @@
-import { simpleGit, SimpleGit, CleanOptions } from "simple-git";
+import { simpleGit, SimpleGit } from "simple-git";
 import { getLogger } from "@/log";
 import { getErrorDetails } from "@/utils/errors";
 

--- a/packages/shortest/src/utils/get-git-info.ts
+++ b/packages/shortest/src/utils/get-git-info.ts
@@ -14,7 +14,7 @@ export const getGitInfo = async (): Promise<GitInfo> => {
   const log = getLogger();
 
   try {
-    const git: SimpleGit = simpleGit().clean(CleanOptions.FORCE);
+    const git: SimpleGit = simpleGit();
     const branchInfo = await git.branch();
     return {
       branch: branchInfo.current,

--- a/packages/shortest/tests/unit/log/log.test.ts
+++ b/packages/shortest/tests/unit/log/log.test.ts
@@ -75,6 +75,7 @@ describe("Log", () => {
           message,
         }),
         "terminal",
+        process.stdout,
         undefined,
       );
     });
@@ -86,6 +87,7 @@ describe("Log", () => {
           message: "Hello World 123",
         }),
         "terminal",
+        process.stdout,
         undefined,
       );
     });
@@ -99,6 +101,7 @@ describe("Log", () => {
           metadata,
         }),
         "terminal",
+        process.stdout,
         undefined,
       );
     });
@@ -124,6 +127,7 @@ describe("Log", () => {
           metadata: { userId: 123, action: "login" },
         }),
         "terminal",
+        process.stdout,
         undefined,
       );
     });
@@ -135,6 +139,7 @@ describe("Log", () => {
           message: "undefined null message",
         }),
         "terminal",
+        process.stdout,
         undefined,
       );
     });
@@ -147,6 +152,7 @@ describe("Log", () => {
           message: `Time is ${date}`,
         }),
         "terminal",
+        process.stdout,
         undefined,
       );
     });
@@ -166,6 +172,7 @@ describe("Log", () => {
       expect(LogOutput.render).toHaveBeenCalledWith(
         expect.any(Object),
         "terminal",
+        process.stdout,
         expect.objectContaining({
           name: "Database",
         }),
@@ -180,6 +187,7 @@ describe("Log", () => {
       expect(LogOutput.render).toHaveBeenCalledWith(
         expect.any(Object),
         "terminal",
+        process.stdout,
         expect.objectContaining({
           name: "Query",
           parent: expect.objectContaining({
@@ -198,6 +206,7 @@ describe("Log", () => {
       expect(LogOutput.render).toHaveBeenCalledWith(
         expect.any(Object),
         "terminal",
+        process.stdout,
         expect.objectContaining({
           name: "Parent",
           parent: undefined,
@@ -214,6 +223,7 @@ describe("Log", () => {
       expect(LogOutput.render).toHaveBeenCalledWith(
         expect.any(Object),
         "terminal",
+        process.stdout,
         undefined,
       );
     });

--- a/packages/shortest/tests/unit/log/output.test.ts
+++ b/packages/shortest/tests/unit/log/output.test.ts
@@ -42,7 +42,7 @@ describe("LogOutput", () => {
   describe("terminal format", () => {
     it("renders basic log message", () => {
       const event = new LogEvent("info", "test message");
-      LogOutput.render(event, "terminal");
+      LogOutput.render(event, "terminal", process.stdout);
 
       expect(console.info).toHaveBeenCalledWith(
         `cyan(info${" ".repeat(maxLevelLength - 4)}) | ${mockTimestamp} | test message`,
@@ -54,7 +54,7 @@ describe("LogOutput", () => {
         userId: 123,
         details: { key: "value" },
       });
-      LogOutput.render(event, "terminal");
+      LogOutput.render(event, "terminal", process.stdout);
 
       expect(console.debug).toHaveBeenCalledWith(
         `green(debug${" ".repeat(maxLevelLength - 5)}) | ${mockTimestamp} | test with metadata | dim(userId)=123 dim(details)={\n  "key": "value"\n}\n`,
@@ -65,7 +65,7 @@ describe("LogOutput", () => {
   describe("reporter format", () => {
     it("renders basic message", () => {
       const event = new LogEvent("info", "test message");
-      LogOutput.render(event, "reporter");
+      LogOutput.render(event, "reporter", process.stdout);
 
       expect(process.stdout.write).toHaveBeenCalledWith("test message\n");
     });
@@ -75,7 +75,7 @@ describe("LogOutput", () => {
       const child = new LogGroup({} as any, "Child", root);
       const event = new LogEvent("info", "test message");
 
-      LogOutput.render(event, "reporter", child);
+      LogOutput.render(event, "reporter", process.stdout, child);
 
       expect(process.stdout.write).toHaveBeenCalledWith("    test message\n");
     });
@@ -84,9 +84,9 @@ describe("LogOutput", () => {
   describe("error handling", () => {
     it("throws on unsupported format", () => {
       const event = new LogEvent("info", "test");
-      expect(() => LogOutput.render(event, "invalid" as any)).toThrow(
-        "Unsupported log format: invalid",
-      );
+      expect(() =>
+        LogOutput.render(event, "invalid" as any, process.stdout),
+      ).toThrow("Unsupported log format: invalid");
     });
   });
 
@@ -99,7 +99,7 @@ describe("LogOutput", () => {
       ["trace", "gray", "log"],
     ])("uses correct color and method for %s level", (level, color, method) => {
       const event = new LogEvent(level as any, "test message");
-      LogOutput.render(event, "terminal");
+      LogOutput.render(event, "terminal", process.stdout);
 
       const paddedLevel = level.padEnd(maxLevelLength);
       let message = "test message";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,12 @@ importers:
       '@babel/types':
         specifier: ^7.26.9
         version: 7.26.9
+      '@inquirer/prompts':
+        specifier: ^7.4.0
+        version: 7.4.0(@types/node@20.17.17)
+      '@listr2/prompt-adapter-inquirer':
+        specifier: ^2.0.18
+        version: 2.0.18(@inquirer/prompts@7.4.0(@types/node@20.17.17))
       '@netlify/framework-info':
         specifier: ^9.9.2
         version: 9.9.2
@@ -281,7 +287,7 @@ importers:
         version: 16.4.7
       esbuild:
         specifier: ^0.20.1
-        version: 0.20.2
+        version: 0.24.2
       expect:
         specifier: ^29.7.0
         version: 29.7.0
@@ -685,12 +691,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.20.2':
-    resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
@@ -717,12 +717,6 @@ packages:
 
   '@esbuild/android-arm64@0.19.12':
     resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.20.2':
-    resolution: {integrity: sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -757,12 +751,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.20.2':
-    resolution: {integrity: sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.21.5':
     resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
@@ -789,12 +777,6 @@ packages:
 
   '@esbuild/android-x64@0.19.12':
     resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.20.2':
-    resolution: {integrity: sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -829,12 +811,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.20.2':
-    resolution: {integrity: sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.21.5':
     resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
@@ -861,12 +837,6 @@ packages:
 
   '@esbuild/darwin-x64@0.19.12':
     resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.20.2':
-    resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -901,12 +871,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.20.2':
-    resolution: {integrity: sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.21.5':
     resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
@@ -933,12 +897,6 @@ packages:
 
   '@esbuild/freebsd-x64@0.19.12':
     resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.20.2':
-    resolution: {integrity: sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -973,12 +931,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.20.2':
-    resolution: {integrity: sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.21.5':
     resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
@@ -1005,12 +957,6 @@ packages:
 
   '@esbuild/linux-arm@0.19.12':
     resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.20.2':
-    resolution: {integrity: sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -1045,12 +991,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.20.2':
-    resolution: {integrity: sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.21.5':
     resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
@@ -1077,12 +1017,6 @@ packages:
 
   '@esbuild/linux-loong64@0.19.12':
     resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.20.2':
-    resolution: {integrity: sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -1117,12 +1051,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.20.2':
-    resolution: {integrity: sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.21.5':
     resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
@@ -1149,12 +1077,6 @@ packages:
 
   '@esbuild/linux-ppc64@0.19.12':
     resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.20.2':
-    resolution: {integrity: sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1189,12 +1111,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.20.2':
-    resolution: {integrity: sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.21.5':
     resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
@@ -1225,12 +1141,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.20.2':
-    resolution: {integrity: sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -1257,12 +1167,6 @@ packages:
 
   '@esbuild/linux-x64@0.19.12':
     resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.20.2':
-    resolution: {integrity: sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1309,12 +1213,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.20.2':
-    resolution: {integrity: sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
@@ -1357,12 +1255,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.20.2':
-    resolution: {integrity: sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
@@ -1389,12 +1281,6 @@ packages:
 
   '@esbuild/sunos-x64@0.19.12':
     resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/sunos-x64@0.20.2':
-    resolution: {integrity: sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -1429,12 +1315,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.20.2':
-    resolution: {integrity: sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -1465,12 +1345,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.20.2':
-    resolution: {integrity: sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
@@ -1497,12 +1371,6 @@ packages:
 
   '@esbuild/win32-x64@0.19.12':
     resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.20.2':
-    resolution: {integrity: sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -1703,6 +1571,131 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/checkbox@4.1.4':
+    resolution: {integrity: sha512-d30576EZdApjAMceijXA5jDzRQHT/MygbC+J8I7EqA6f/FRpYxlRtRJbHF8gHeWYeSdOuTEJqonn7QLB1ELezA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.8':
+    resolution: {integrity: sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.1.9':
+    resolution: {integrity: sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.9':
+    resolution: {integrity: sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.11':
+    resolution: {integrity: sha512-OZSUW4hFMW2TYvX/Sv+NnOZgO8CHT2TU1roUCUIF2T+wfw60XFRRp9MRUPCT06cRnKL+aemt2YmTWwt7rOrNEA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.11':
+    resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.1.8':
+    resolution: {integrity: sha512-WXJI16oOZ3/LiENCAxe8joniNp8MQxF6Wi5V+EBbVA0ZIOpFcL4I9e7f7cXse0HJeIPCWO8Lcgnk98juItCi7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.11':
+    resolution: {integrity: sha512-pQK68CsKOgwvU2eA53AG/4npRTH2pvs/pZ2bFvzpBhrznh8Mcwt19c+nMO7LHRr3Vreu1KPhNBF3vQAKrjIulw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.11':
+    resolution: {integrity: sha512-dH6zLdv+HEv1nBs96Case6eppkRggMe8LoOTl30+Gq5Wf27AO/vHFgStTVz4aoevLdNXqwE23++IXGw4eiOXTg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.4.0':
+    resolution: {integrity: sha512-EZiJidQOT4O5PYtqnu1JbF0clv36oW2CviR66c7ma4LsupmmQlUwmdReGKRp456OWPWMz3PdrPiYg3aCk3op2w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.0.11':
+    resolution: {integrity: sha512-uAYtTx0IF/PqUAvsRrF3xvnxJV516wmR6YVONOmCWJbbt87HcDHLfL9wmBQFbNJRv5kCjdYKrZcavDkH3sVJPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.0.11':
+    resolution: {integrity: sha512-9CWQT0ikYcg6Ls3TOa7jljsD7PgjcsYEM0bYE+Gkz+uoW9u8eaJCRHJKkucpRE5+xKtaaDbrND+nPDoxzjYyew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.1.0':
+    resolution: {integrity: sha512-z0a2fmgTSRN+YBuiK1ROfJ2Nvrpij5lVN3gPDkQGhavdvIVGHGW29LwYZfM/j42Ai2hUghTI/uoBuTbrJk42bA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@1.5.5':
+    resolution: {integrity: sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.5':
+    resolution: {integrity: sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1745,6 +1738,12 @@ packages:
 
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
+  '@listr2/prompt-adapter-inquirer@2.0.18':
+    resolution: {integrity: sha512-0hz44rAcrphyXcA8IS7EJ2SCoaBZD2u5goE8S/e+q/DL+dOGpqpcLidVOFeLG3VgML62SXmfRLAhWt0zL1oW4Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@inquirer/prompts': '>= 3 < 8'
 
   '@microsoft/api-extractor-model@7.30.1':
     resolution: {integrity: sha512-CTS2PlASJHxVY8hqHORVb1HdECWOEMcMnM6/kDkPr0RZapAFSIHhg9D4jxuE8g+OWYHtPc10LCpmde5pylTRlA==}
@@ -3117,6 +3116,10 @@ packages:
   ajv@8.13.0:
     resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
 
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
   ansi-escapes@7.0.0:
     resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
     engines: {node: '>=18'}
@@ -3322,6 +3325,9 @@ packages:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chardet@0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
@@ -3355,6 +3361,10 @@ packages:
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -3746,11 +3756,6 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
-  esbuild@0.20.2:
-    resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
-    engines: {node: '>=12'}
-    hasBin: true
-
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -3915,6 +3920,10 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  external-editor@3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
 
   fast-content-type-parse@2.0.1:
     resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
@@ -4157,6 +4166,10 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -4603,6 +4616,14 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -4719,6 +4740,10 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
 
   otplib@12.0.1:
     resolution: {integrity: sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==}
@@ -5530,6 +5555,10 @@ packages:
     resolution: {integrity: sha512-/W1YVgYVJd9ZDjey5NXadNh0mJXkiUMUue9Zebd0vpdo1sU+H4zFFTaJ1RKD4N6KFoHfcXy6l+Vu7bh+bdWCzA==}
     hasBin: true
 
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -5622,6 +5651,10 @@ packages:
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
 
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
@@ -5915,6 +5948,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -5972,6 +6009,10 @@ packages:
   yocto-queue@1.1.1:
     resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
     engines: {node: '>=12.20'}
+
+  yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
 
   zod-to-json-schema@3.24.1:
     resolution: {integrity: sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==}
@@ -6386,9 +6427,6 @@ snapshots:
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.20.2':
-    optional: true
-
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -6402,9 +6440,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.19.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.20.2':
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
@@ -6422,9 +6457,6 @@ snapshots:
   '@esbuild/android-arm@0.19.12':
     optional: true
 
-  '@esbuild/android-arm@0.20.2':
-    optional: true
-
   '@esbuild/android-arm@0.21.5':
     optional: true
 
@@ -6438,9 +6470,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.19.12':
-    optional: true
-
-  '@esbuild/android-x64@0.20.2':
     optional: true
 
   '@esbuild/android-x64@0.21.5':
@@ -6458,9 +6487,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.19.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.20.2':
-    optional: true
-
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
@@ -6474,9 +6500,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.19.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.20.2':
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
@@ -6494,9 +6517,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.19.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.20.2':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
@@ -6510,9 +6530,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.19.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.20.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
@@ -6530,9 +6547,6 @@ snapshots:
   '@esbuild/linux-arm64@0.19.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.20.2':
-    optional: true
-
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
@@ -6546,9 +6560,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.19.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.20.2':
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
@@ -6566,9 +6577,6 @@ snapshots:
   '@esbuild/linux-ia32@0.19.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.20.2':
-    optional: true
-
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
@@ -6582,9 +6590,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.19.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.20.2':
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
@@ -6602,9 +6607,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.19.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.20.2':
-    optional: true
-
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
@@ -6618,9 +6620,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.19.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.20.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
@@ -6638,9 +6637,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.19.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.20.2':
-    optional: true
-
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
@@ -6656,9 +6652,6 @@ snapshots:
   '@esbuild/linux-s390x@0.19.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.20.2':
-    optional: true
-
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
@@ -6672,9 +6665,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-x64@0.19.12':
-    optional: true
-
-  '@esbuild/linux-x64@0.20.2':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -6698,9 +6688,6 @@ snapshots:
   '@esbuild/netbsd-x64@0.19.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.20.2':
-    optional: true
-
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
@@ -6722,9 +6709,6 @@ snapshots:
   '@esbuild/openbsd-x64@0.19.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.20.2':
-    optional: true
-
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
@@ -6738,9 +6722,6 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.19.12':
-    optional: true
-
-  '@esbuild/sunos-x64@0.20.2':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -6758,9 +6739,6 @@ snapshots:
   '@esbuild/win32-arm64@0.19.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.20.2':
-    optional: true
-
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
@@ -6776,9 +6754,6 @@ snapshots:
   '@esbuild/win32-ia32@0.19.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.20.2':
-    optional: true
-
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
@@ -6792,9 +6767,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.19.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.20.2':
     optional: true
 
   '@esbuild/win32-x64@0.21.5':
@@ -6955,6 +6927,126 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
+  '@inquirer/checkbox@4.1.4(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/core': 10.1.9(@types/node@20.17.17)
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.5(@types/node@20.17.17)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/confirm@5.1.8(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/core': 10.1.9(@types/node@20.17.17)
+      '@inquirer/type': 3.0.5(@types/node@20.17.17)
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/core@10.1.9(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.5(@types/node@20.17.17)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/editor@4.2.9(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/core': 10.1.9(@types/node@20.17.17)
+      '@inquirer/type': 3.0.5(@types/node@20.17.17)
+      external-editor: 3.1.0
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/expand@4.0.11(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/core': 10.1.9(@types/node@20.17.17)
+      '@inquirer/type': 3.0.5(@types/node@20.17.17)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/figures@1.0.11': {}
+
+  '@inquirer/input@4.1.8(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/core': 10.1.9(@types/node@20.17.17)
+      '@inquirer/type': 3.0.5(@types/node@20.17.17)
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/number@3.0.11(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/core': 10.1.9(@types/node@20.17.17)
+      '@inquirer/type': 3.0.5(@types/node@20.17.17)
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/password@4.0.11(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/core': 10.1.9(@types/node@20.17.17)
+      '@inquirer/type': 3.0.5(@types/node@20.17.17)
+      ansi-escapes: 4.3.2
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/prompts@7.4.0(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/checkbox': 4.1.4(@types/node@20.17.17)
+      '@inquirer/confirm': 5.1.8(@types/node@20.17.17)
+      '@inquirer/editor': 4.2.9(@types/node@20.17.17)
+      '@inquirer/expand': 4.0.11(@types/node@20.17.17)
+      '@inquirer/input': 4.1.8(@types/node@20.17.17)
+      '@inquirer/number': 3.0.11(@types/node@20.17.17)
+      '@inquirer/password': 4.0.11(@types/node@20.17.17)
+      '@inquirer/rawlist': 4.0.11(@types/node@20.17.17)
+      '@inquirer/search': 3.0.11(@types/node@20.17.17)
+      '@inquirer/select': 4.1.0(@types/node@20.17.17)
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/rawlist@4.0.11(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/core': 10.1.9(@types/node@20.17.17)
+      '@inquirer/type': 3.0.5(@types/node@20.17.17)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/search@3.0.11(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/core': 10.1.9(@types/node@20.17.17)
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.5(@types/node@20.17.17)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/select@4.1.0(@types/node@20.17.17)':
+    dependencies:
+      '@inquirer/core': 10.1.9(@types/node@20.17.17)
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.5(@types/node@20.17.17)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 20.17.17
+
+  '@inquirer/type@1.5.5':
+    dependencies:
+      mute-stream: 1.0.0
+
+  '@inquirer/type@3.0.5(@types/node@20.17.17)':
+    optionalDependencies:
+      '@types/node': 20.17.17
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -7011,6 +7103,11 @@ snapshots:
       - supports-color
 
   '@kwsites/promise-deferred@1.1.1': {}
+
+  '@listr2/prompt-adapter-inquirer@2.0.18(@inquirer/prompts@7.4.0(@types/node@20.17.17))':
+    dependencies:
+      '@inquirer/prompts': 7.4.0(@types/node@20.17.17)
+      '@inquirer/type': 1.5.5
 
   '@microsoft/api-extractor-model@7.30.1(@types/node@20.17.17)':
     dependencies:
@@ -8373,6 +8470,10 @@ snapshots:
       require-from-string: 2.0.2
       uri-js: 4.4.1
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
   ansi-escapes@7.0.0:
     dependencies:
       environment: 1.1.0
@@ -8619,6 +8720,8 @@ snapshots:
 
   chalk@5.4.1: {}
 
+  chardet@0.7.0: {}
+
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
@@ -8662,6 +8765,8 @@ snapshots:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.2.0
+
+  cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
 
@@ -9057,32 +9162,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.19.12
       '@esbuild/win32-x64': 0.19.12
 
-  esbuild@0.20.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.20.2
-      '@esbuild/android-arm': 0.20.2
-      '@esbuild/android-arm64': 0.20.2
-      '@esbuild/android-x64': 0.20.2
-      '@esbuild/darwin-arm64': 0.20.2
-      '@esbuild/darwin-x64': 0.20.2
-      '@esbuild/freebsd-arm64': 0.20.2
-      '@esbuild/freebsd-x64': 0.20.2
-      '@esbuild/linux-arm': 0.20.2
-      '@esbuild/linux-arm64': 0.20.2
-      '@esbuild/linux-ia32': 0.20.2
-      '@esbuild/linux-loong64': 0.20.2
-      '@esbuild/linux-mips64el': 0.20.2
-      '@esbuild/linux-ppc64': 0.20.2
-      '@esbuild/linux-riscv64': 0.20.2
-      '@esbuild/linux-s390x': 0.20.2
-      '@esbuild/linux-x64': 0.20.2
-      '@esbuild/netbsd-x64': 0.20.2
-      '@esbuild/openbsd-x64': 0.20.2
-      '@esbuild/sunos-x64': 0.20.2
-      '@esbuild/win32-arm64': 0.20.2
-      '@esbuild/win32-ia32': 0.20.2
-      '@esbuild/win32-x64': 0.20.2
-
   esbuild@0.21.5:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.21.5
@@ -9359,6 +9438,12 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
+  external-editor@3.1.0:
+    dependencies:
+      chardet: 0.7.0
+      iconv-lite: 0.4.24
+      tmp: 0.0.33
+
   fast-content-type-parse@2.0.1: {}
 
   fast-deep-equal@3.1.3: {}
@@ -9612,6 +9697,10 @@ snapshots:
       - supports-color
 
   human-signals@5.0.0: {}
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.6.3:
     dependencies:
@@ -10061,6 +10150,10 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mute-stream@1.0.0: {}
+
+  mute-stream@2.0.0: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -10186,6 +10279,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  os-tmpdir@1.0.2: {}
 
   otplib@12.0.1:
     dependencies:
@@ -11091,6 +11186,10 @@ snapshots:
     dependencies:
       tldts-core: 6.1.70
 
+  tmp@0.0.33:
+    dependencies:
+      os-tmpdir: 1.0.2
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -11189,6 +11288,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-detect@4.1.0: {}
+
+  type-fest@0.21.3: {}
 
   type-fest@2.19.0: {}
 
@@ -11474,6 +11575,12 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -11515,6 +11622,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.1.1: {}
+
+  yoctocolors-cjs@2.1.2: {}
 
   zod-to-json-schema@3.24.1(zod@3.24.1):
     dependencies:


### PR DESCRIPTION
Enhanced CLI initialization with interactive prompts for sample test generation, config customization, API key setup, and login credentials to streamline user onboarding with guided setup flow.

Ref https://github.com/antiwork/shortest/discussions/375#discussioncomment-12559992

### Helper demo

The test file was not properly formatted due to some issues with detecting the ESLint config (no padding lines between  statements)

https://github.com/user-attachments/assets/b1f28e64-1ea6-431d-ab85-334e0ec964c8

### Iffy demo

Shortest is already installed on the project

https://github.com/user-attachments/assets/c821c16b-8043-4056-9efa-1a9f1d5da9f1