### PR TITLE
feat(ai): Add Claude 4 model support and set as default

### DIFF
--- a/packages/shortest/src/tools/tool-registry.ts
+++ b/packages/shortest/src/tools/tool-registry.ts
@@ -36,7 +36,7 @@ export const anthropicToolTypeSchema = z.enum(["computer", "bash"]);
 export type AnthropicToolType = z.infer<typeof anthropicToolTypeSchema>;
 
 // eslint-disable-next-line zod/require-zod-schema-types
-export type AnthropicModelFamily = "claude-3-5" | "claude-3-7";
+export type AnthropicModelFamily = "claude-3-5" | "claude-3-7" | "claude-4";
 
 /**
  * List of all Anthropic-defined tools for all models
@@ -48,6 +48,10 @@ export type AnthropicToolVersion = "20241022" | "20250124";
 
 const ANTHROPIC_MODEL_TO_FAMILY: Record<AnthropicModel, AnthropicModelFamily> =
   {
+    "claude-4-sonnet-20250514": "claude-4",
+    "claude-4-sonnet-latest": "claude-4",
+    "claude-4-opus-20250514": "claude-4",
+    "claude-4-opus-latest": "claude-4",
     "claude-3-5-sonnet-latest": "claude-3-5",
     "claude-3-5-sonnet-20241022": "claude-3-5",
     "claude-3-7-sonnet-latest": "claude-3-7",
@@ -63,6 +67,10 @@ const ANTHROPIC_TOOL_VERSION_MAP: Record<
     bash: "20241022",
   },
   "claude-3-7": {
+    computer: "20250124",
+    bash: "20250124",
+  },
+  "claude-4": {
     computer: "20250124",
     bash: "20250124",
   },

--- a/packages/shortest/src/types/config.ts
+++ b/packages/shortest/src/types/config.ts
@@ -16,6 +16,10 @@ export type CLIOptions = z.infer<typeof cliOptionsSchema>;
  * @see https://docs.anthropic.com/en/docs/about-claude/models/all-models
  */
 export const ANTHROPIC_MODELS = [
+  "claude-4-sonnet-20250514",
+  "claude-4-sonnet-latest",
+  "claude-4-opus-20250514",
+  "claude-4-opus-latest",
   "claude-3-5-sonnet-20241022",
   "claude-3-5-sonnet-latest",
   "claude-3-7-sonnet-20250219",

--- a/packages/shortest/tests/unit/config.test.ts
+++ b/packages/shortest/tests/unit/config.test.ts
@@ -31,7 +31,7 @@ describe("Config parsing", () => {
       expect(config.testPattern).toBe("**/*.test.ts");
       expect(config.ai).toEqual({
         apiKey: "foo",
-        model: "claude-3-5-sonnet-20241022",
+        model: "claude-4-sonnet-20250514",
         provider: "anthropic",
       });
       expect(config.caching).toEqual({
@@ -142,7 +142,7 @@ describe("Config parsing", () => {
           expect(config.ai).toEqual({
             apiKey: "env-api-key",
             provider: "anthropic",
-            model: "claude-3-5-sonnet-20241022",
+            model: "claude-4-sonnet-20250514",
           });
         });
       });
@@ -164,7 +164,7 @@ describe("Config parsing", () => {
           expect(config.ai).toEqual({
             apiKey: "shortest-env-api-key",
             provider: "anthropic",
-            model: "claude-3-5-sonnet-20241022",
+            model: "claude-4-sonnet-20250514",
           });
         });
       });
@@ -176,7 +176,7 @@ describe("Config parsing", () => {
           expect(config.ai).toEqual({
             apiKey: "explicit-api-key",
             provider: "anthropic",
-            model: "claude-3-5-sonnet-20241022",
+            model: "claude-4-sonnet-20250514",
           });
         });
       });
@@ -216,7 +216,7 @@ describe("Config parsing", () => {
           ai: { ...baseConfig.ai, model: "invalid-model" as any },
         };
         expect(() => parseConfig(userConfig)).toThrowError(
-          /Invalid shortest\.config\n(?:\u001b\[\d+m)?ai\.model(?:\u001b\[\d+m)?: Invalid enum value\. Expected 'claude-3-5-sonnet-20241022' | 'claude-3-5-sonnet-latest', received 'invalid-model'(?:\s\(received: "invalid-model"\))?/,
+          /Invalid shortest\.config\n(?:\u001b\[\d+m)?ai\.model(?:\u001b\[\d+m)?: Invalid enum value\. Expected 'claude-4-sonnet-20250514' | 'claude-4-sonnet-latest' | 'claude-4-opus-20250514' | 'claude-4-opus-latest' | 'claude-3-5-sonnet-20241022' | 'claude-3-5-sonnet-latest' | 'claude-3-7-sonnet-20250219' | 'claude-3-7-sonnet-latest', received 'invalid-model'(?:\s\(received: "invalid-model"\))?/,
         );
       });
     });
@@ -242,7 +242,7 @@ describe("Config parsing", () => {
           expect(config.ai).toEqual({
             provider: "anthropic",
             apiKey: "deprecated-api-key",
-            model: "claude-3-5-sonnet-20241022",
+            model: "claude-4-sonnet-20250514",
           });
         });
       });

--- a/packages/shortest/tests/unit/initialize-config.test.ts
+++ b/packages/shortest/tests/unit/initialize-config.test.ts
@@ -41,7 +41,7 @@ describe("initializeConfig", () => {
       ai: {
         provider: "anthropic",
         apiKey: "test-key",
-        model: "claude-3-5-sonnet-20241022",
+        model: "claude-4-sonnet-20250514",
       },
       caching: {
         enabled: true,
@@ -76,7 +76,7 @@ describe("initializeConfig", () => {
       ai: {
         provider: "anthropic",
         apiKey: "test-key",
-        model: "claude-3-5-sonnet-20241022",
+        model: "claude-4-sonnet-20250514",
       },
       caching: {
         enabled: true,
@@ -161,7 +161,7 @@ describe("initializeConfig", () => {
         ai: {
           provider: "anthropic",
           apiKey: "test-key",
-          model: "claude-3-5-sonnet-20241022",
+          model: "claude-4-sonnet-20250514",
         },
         caching: {
           enabled: false,


### PR DESCRIPTION
This PR adds support for Claude 4 models and sets Claude 4 Sonnet as the new default model. Adds claude-4-sonnet-20250514, claude-4-sonnet-latest, claude-4-opus-20250514, claude-4-opus-latest models. Updates AnthropicModelFamily to include claude-4. Sets claude-4-sonnet-20250514 as new default model. Updates tool version mappings for Claude 4 models. Updates all related tests. All unit tests pass and CLI builds successfully. Closes #447