### PR TITLE
chore: extract duplicate test setup code into shared helper

### DIFF
--- a/packages/shortest/tests/e2e/test-browser.ts
+++ b/packages/shortest/tests/e2e/test-browser.ts
@@ -1,9 +1,9 @@
 import pc from "picocolors";
+import { createBrowserTool } from "./test-helpers";
 import { BrowserManager } from "@/browser/manager";
 import { createTestCase } from "@/core/runner/test-case";
 import { TestRun } from "@/core/runner/test-run";
 import { getConfig } from "@/index";
-import { createBrowserTool } from "./test-helpers";
 
 export const main = async () => {
   const browserManager = new BrowserManager(getConfig());

--- a/packages/shortest/tests/e2e/test-browser.ts
+++ b/packages/shortest/tests/e2e/test-browser.ts
@@ -1,11 +1,9 @@
 import pc from "picocolors";
-import * as playwright from "playwright";
-import { request } from "playwright";
-import { BrowserTool } from "@/browser/core/browser-tool";
 import { BrowserManager } from "@/browser/manager";
 import { createTestCase } from "@/core/runner/test-case";
 import { TestRun } from "@/core/runner/test-run";
 import { getConfig } from "@/index";
+import { createBrowserTool } from "./test-helpers";
 
 export const main = async () => {
   const browserManager = new BrowserManager(getConfig());
@@ -23,31 +21,7 @@ export const main = async () => {
     const context = await browserManager.launch();
     const page = context.pages()[0];
 
-    const browserTool = new BrowserTool(page, browserManager, {
-      width: 1920,
-      height: 1080,
-      testContext: {
-        page,
-        browser: browserManager.getBrowser()!,
-        testRun,
-        currentStepIndex: 0,
-        playwright: {
-          ...playwright,
-          request: {
-            ...request,
-            newContext: async (options?: {
-              extraHTTPHeaders?: Record<string, string>;
-            }) => {
-              const requestContext = await request.newContext({
-                baseURL: getConfig().baseUrl,
-                ...options,
-              });
-              return requestContext;
-            },
-          },
-        },
-      },
-    });
+    const browserTool = createBrowserTool(page, browserManager, testRun);
 
     // Navigate to a page with a sign in button
     await page.goto("http://localhost:3000");

--- a/packages/shortest/tests/e2e/test-email-rendering.ts
+++ b/packages/shortest/tests/e2e/test-email-rendering.ts
@@ -1,11 +1,11 @@
 import Mailosaur from "mailosaur";
 import pc from "picocolors";
 import { chromium } from "playwright";
+import { createBrowserTool } from "./test-helpers";
 import { BrowserManager } from "@/browser/manager";
 import { createTestCase } from "@/core/runner/test-case";
 import { TestRun } from "@/core/runner/test-run";
 import { getConfig, initializeConfig } from "@/index";
-import { createBrowserTool } from "./test-helpers";
 
 export const main = async () => {
   console.log(pc.cyan("\n📧 Testing Email"));

--- a/packages/shortest/tests/e2e/test-email-rendering.ts
+++ b/packages/shortest/tests/e2e/test-email-rendering.ts
@@ -1,12 +1,11 @@
 import Mailosaur from "mailosaur";
 import pc from "picocolors";
-import * as playwright from "playwright";
-import { chromium, request } from "playwright";
-import { BrowserTool } from "@/browser/core/browser-tool";
+import { chromium } from "playwright";
 import { BrowserManager } from "@/browser/manager";
 import { createTestCase } from "@/core/runner/test-case";
 import { TestRun } from "@/core/runner/test-run";
 import { getConfig, initializeConfig } from "@/index";
+import { createBrowserTool } from "./test-helpers";
 
 export const main = async () => {
   console.log(pc.cyan("\n📧 Testing Email"));
@@ -49,29 +48,9 @@ export const main = async () => {
     const testRun = TestRun.create(testCase);
     testRun.markRunning();
 
-    const browserTool = new BrowserTool(page, browserManager, {
+    const browserTool = createBrowserTool(page, browserManager, testRun, {
       width: 1280,
       height: 720,
-      testContext: {
-        page,
-        browser: browserManager.getBrowser()!,
-        playwright: {
-          ...playwright,
-          request: {
-            ...request,
-            newContext: async (options?: {
-              extraHTTPHeaders?: Record<string, string>;
-            }) => {
-              const requestContext = await request.newContext({
-                baseURL: config.baseUrl,
-                ...options,
-              });
-              return requestContext;
-            },
-          },
-        },
-        testRun,
-      },
     });
 
     // 3. Test render_email tool

--- a/packages/shortest/tests/e2e/test-github-login.ts
+++ b/packages/shortest/tests/e2e/test-github-login.ts
@@ -1,10 +1,10 @@
 import pc from "picocolors";
+import { createBrowserTool } from "./test-helpers";
 import { GitHubTool } from "@/browser/integrations/github";
 import { BrowserManager } from "@/browser/manager";
 import { createTestCase } from "@/core/runner/test-case";
 import { TestRun } from "@/core/runner/test-run";
 import { getConfig, initializeConfig } from "@/index";
-import { createBrowserTool } from "./test-helpers";
 
 export const main = async () => {
   const browserManager = new BrowserManager(getConfig());

--- a/packages/shortest/tests/e2e/test-github-login.ts
+++ b/packages/shortest/tests/e2e/test-github-login.ts
@@ -1,12 +1,10 @@
 import pc from "picocolors";
-import * as playwright from "playwright";
-import { request } from "playwright";
-import { BrowserTool } from "@/browser/core/browser-tool";
 import { GitHubTool } from "@/browser/integrations/github";
 import { BrowserManager } from "@/browser/manager";
 import { createTestCase } from "@/core/runner/test-case";
 import { TestRun } from "@/core/runner/test-run";
 import { getConfig, initializeConfig } from "@/index";
+import { createBrowserTool } from "./test-helpers";
 
 export const main = async () => {
   const browserManager = new BrowserManager(getConfig());
@@ -25,31 +23,7 @@ export const main = async () => {
     const testRun = TestRun.create(testCase);
     testRun.markRunning();
 
-    let browserTool = new BrowserTool(page, browserManager, {
-      width: 1920,
-      height: 1080,
-      testContext: {
-        page,
-        browser: browserManager.getBrowser()!,
-        testRun,
-        currentStepIndex: 0,
-        playwright: {
-          ...playwright,
-          request: {
-            ...request,
-            newContext: async (options?: {
-              extraHTTPHeaders?: Record<string, string>;
-            }) => {
-              const requestContext = await request.newContext({
-                baseURL: getConfig().baseUrl,
-                ...options,
-              });
-              return requestContext;
-            },
-          },
-        },
-      },
-    });
+    let browserTool = createBrowserTool(page, browserManager, testRun);
 
     console.log(pc.cyan("\n🧹 Clearing initial session..."));
     const result = await browserTool.execute({ action: "clear_session" });
@@ -61,31 +35,7 @@ export const main = async () => {
     page = context.pages()[0];
 
     // Update browserTool with new page
-    browserTool = new BrowserTool(page, browserManager, {
-      width: 1920,
-      height: 1080,
-      testContext: {
-        page,
-        browser: browserManager.getBrowser()!,
-        testRun,
-        currentStepIndex: 0,
-        playwright: {
-          ...playwright,
-          request: {
-            ...request,
-            newContext: async (options?: {
-              extraHTTPHeaders?: Record<string, string>;
-            }) => {
-              const requestContext = await request.newContext({
-                baseURL: getConfig().baseUrl,
-                ...options,
-              });
-              return requestContext;
-            },
-          },
-        },
-      },
-    });
+    browserTool = createBrowserTool(page, browserManager, testRun);
 
     // Continue with fresh page reference
     await page.waitForSelector('button:has-text("Sign in")', {
@@ -116,31 +66,7 @@ export const main = async () => {
     const newPage = newContext.pages()[0];
 
     // Create new browser tool instance
-    browserTool = new BrowserTool(page, browserManager, {
-      width: 1920,
-      height: 1080,
-      testContext: {
-        page,
-        browser: browserManager.getBrowser()!,
-        testRun,
-        currentStepIndex: 0,
-        playwright: {
-          ...playwright,
-          request: {
-            ...request,
-            newContext: async (options?: {
-              extraHTTPHeaders?: Record<string, string>;
-            }) => {
-              const requestContext = await request.newContext({
-                baseURL: getConfig().baseUrl,
-                ...options,
-              });
-              return requestContext;
-            },
-          },
-        },
-      },
-    });
+    browserTool = createBrowserTool(page, browserManager, testRun);
 
     console.log(pc.cyan("\n🔍 Checking login state..."));
     await newPage.goto("http://localhost:3000");

--- a/packages/shortest/tests/e2e/test-helpers.ts
+++ b/packages/shortest/tests/e2e/test-helpers.ts
@@ -19,12 +19,12 @@ export interface TestContext {
   };
 }
 
-export function createBrowserTool(
+export const createBrowserTool = (
   page: playwright.Page,
   browserManager: BrowserManager,
   testRun: TestRun,
   options: { width?: number; height?: number } = {}
-): BrowserTool {
+): BrowserTool => {
   const { width = 1920, height = 1080 } = options;
   
   return new BrowserTool(page, browserManager, {
@@ -52,4 +52,4 @@ export function createBrowserTool(
       },
     },
   });
-}
+};

--- a/packages/shortest/tests/e2e/test-helpers.ts
+++ b/packages/shortest/tests/e2e/test-helpers.ts
@@ -1,0 +1,55 @@
+import * as playwright from "playwright";
+import { request } from "playwright";
+import { BrowserTool } from "@/browser/core/browser-tool";
+import { BrowserManager } from "@/browser/manager";
+import { TestRun } from "@/core/runner/test-run";
+import { getConfig } from "@/index";
+
+export interface TestContext {
+  page: playwright.Page;
+  browser: playwright.Browser;
+  testRun: TestRun;
+  currentStepIndex: number;
+  playwright: typeof playwright & {
+    request: typeof request & {
+      newContext: (options?: {
+        extraHTTPHeaders?: Record<string, string>;
+      }) => Promise<playwright.APIRequestContext>;
+    };
+  };
+}
+
+export function createBrowserTool(
+  page: playwright.Page,
+  browserManager: BrowserManager,
+  testRun: TestRun,
+  options: { width?: number; height?: number } = {}
+): BrowserTool {
+  const { width = 1920, height = 1080 } = options;
+  
+  return new BrowserTool(page, browserManager, {
+    width,
+    height,
+    testContext: {
+      page,
+      browser: browserManager.getBrowser()!,
+      testRun,
+      currentStepIndex: 0,
+      playwright: {
+        ...playwright,
+        request: {
+          ...request,
+          newContext: async (options?: {
+            extraHTTPHeaders?: Record<string, string>;
+          }) => {
+            const requestContext = await request.newContext({
+              baseURL: getConfig().baseUrl,
+              ...options,
+            });
+            return requestContext;
+          },
+        },
+      },
+    },
+  });
+}

--- a/packages/shortest/tests/e2e/test-helpers.ts
+++ b/packages/shortest/tests/e2e/test-helpers.ts
@@ -23,10 +23,10 @@ export const createBrowserTool = (
   page: playwright.Page,
   browserManager: BrowserManager,
   testRun: TestRun,
-  options: { width?: number; height?: number } = {}
+  options: { width?: number; height?: number } = {},
 ): BrowserTool => {
   const { width = 1920, height = 1080 } = options;
-  
+
   return new BrowserTool(page, browserManager, {
     width,
     height,

--- a/packages/shortest/tests/e2e/test-keyboard.ts
+++ b/packages/shortest/tests/e2e/test-keyboard.ts
@@ -1,11 +1,9 @@
 import pc from "picocolors";
-import * as playwright from "playwright";
-import { request } from "playwright";
-import { BrowserTool } from "@/browser/core/browser-tool";
 import { BrowserManager } from "@/browser/manager";
 import { createTestCase } from "@/core/runner/test-case";
 import { TestRun } from "@/core/runner/test-run";
 import { getConfig, initializeConfig } from "@/index";
+import { createBrowserTool } from "./test-helpers";
 
 export const main = async () => {
   const browserManager = new BrowserManager(getConfig());
@@ -23,31 +21,7 @@ export const main = async () => {
     const testRun = TestRun.create(testCase);
     testRun.markRunning();
 
-    const browserTool = new BrowserTool(page, browserManager, {
-      width: 1920,
-      height: 1080,
-      testContext: {
-        page,
-        browser: browserManager.getBrowser()!,
-        testRun,
-        currentStepIndex: 0,
-        playwright: {
-          ...playwright,
-          request: {
-            ...request,
-            newContext: async (options?: {
-              extraHTTPHeaders?: Record<string, string>;
-            }) => {
-              const requestContext = await request.newContext({
-                baseURL: getConfig().baseUrl,
-                ...options,
-              });
-              return requestContext;
-            },
-          },
-        },
-      },
-    });
+    const browserTool = createBrowserTool(page, browserManager, testRun);
 
     // Test 1: Test Page_Down key (exactly as AI sends it)
     console.log(pc.cyan("\nTest 1: Testing Page_Down key"));

--- a/packages/shortest/tests/e2e/test-keyboard.ts
+++ b/packages/shortest/tests/e2e/test-keyboard.ts
@@ -1,9 +1,9 @@
 import pc from "picocolors";
+import { createBrowserTool } from "./test-helpers";
 import { BrowserManager } from "@/browser/manager";
 import { createTestCase } from "@/core/runner/test-case";
 import { TestRun } from "@/core/runner/test-run";
 import { getConfig, initializeConfig } from "@/index";
-import { createBrowserTool } from "./test-helpers";
 
 export const main = async () => {
   const browserManager = new BrowserManager(getConfig());


### PR DESCRIPTION
Removed duplicate BrowserTool initialization code that was repeated across multiple test files by creating a shared createBrowserTool helper function.

## What changed
- Created `test-helpers.ts` with `createBrowserTool` function that encapsulates the common setup
- Updated 5 test files to use the shared helper instead of duplicating the initialization code

## The helper encapsulates:
- BrowserTool instantiation with default dimensions (1920x1080)
- Test context setup including page, browser, and testRun
- Playwright object enhancement with custom request.newContext

## Impact
- **test-browser.ts**: -25 lines
- **test-github-login.ts**: -75 lines (had 3 duplicate occurrences!)
- **test-keyboard.ts**: -25 lines
- **test-email-rendering.ts**: -22 lines
- **test-helpers.ts**: +55 lines (new file)

**Net reduction: 92 lines removed** 🎉

This makes the test code more maintainable and reduces duplication significantly.