### PR TITLE
Add redacted failure reports with screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,16 @@ pnpm shortest --headless        # Run in headless mode using
 
 You can find example tests in the [`examples`](./examples) directory.
 
+### Redacted failure reports
+
+Use `--report` to write a Markdown report bundle for failed runs:
+
+```bash
+pnpm shortest app/login.test.ts --report
+```
+
+Reports are written to `.shortest/reports` by default. Use `--report-dir <path>` to choose a different output directory. Report text is redacted on a best-effort basis and screenshots from the failed run are copied into the report bundle, but screenshots are not machine-redacted, so review the full bundle before sharing it.
+
 ### CI setup
 
 You can run Shortest in your CI/CD pipeline by running tests in headless mode. Make sure to add your Anthropic API key to your CI/CD pipeline secrets.

--- a/packages/shortest/README.md
+++ b/packages/shortest/README.md
@@ -201,6 +201,16 @@ pnpm shortest --headless        # Run in headless mode using
 
 You can find example tests in the [`examples`](./examples) directory.
 
+### Redacted failure reports
+
+Use `--report` to write a Markdown report bundle for failed runs:
+
+```bash
+pnpm shortest app/login.test.ts --report
+```
+
+Reports are written to `.shortest/reports` by default. Use `--report-dir <path>` to choose a different output directory. Report text is redacted on a best-effort basis and screenshots from the failed run are copied into the report bundle, but screenshots are not machine-redacted, so review the full bundle before sharing it.
+
 ### GitHub 2FA login setup
 
 Shortest currently supports login using Github 2FA. For GitHub authentication tests:

--- a/packages/shortest/src/cli/bin.test.ts
+++ b/packages/shortest/src/cli/bin.test.ts
@@ -113,4 +113,34 @@ describe("CLI bin structure", () => {
       commands.shortestCommand,
     );
   });
+
+  test("preserves process exit code set by command actions", async () => {
+    const commands = await import("@/cli/commands");
+
+    vi.spyOn(commands.shortestCommand, "addCommand").mockImplementation(
+      () => commands.shortestCommand,
+    );
+    vi.spyOn(commands.shortestCommand, "parseAsync").mockImplementation(
+      async () => {
+        await Promise.resolve();
+        process.exitCode = 1;
+        return commands.shortestCommand;
+      },
+    );
+    vi.spyOn(commands.initCommand, "copyInheritedSettings").mockImplementation(
+      () => commands.initCommand,
+    );
+    vi.spyOn(
+      commands.githubCodeCommand,
+      "copyInheritedSettings",
+    ).mockImplementation(() => commands.githubCodeCommand);
+    vi.spyOn(
+      commands.cacheCommands,
+      "copyInheritedSettings",
+    ).mockImplementation(() => commands.cacheCommands);
+
+    await import("@/cli/bin");
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
 });

--- a/packages/shortest/src/cli/bin.ts
+++ b/packages/shortest/src/cli/bin.ts
@@ -50,7 +50,7 @@ generateCommand.copyInheritedSettings(shortestCommand);
 const main = async () => {
   try {
     await shortestCommand.parseAsync();
-    process.exit(0);
+    process.exit(process.exitCode ?? 0);
   } catch (error) {
     const log = getLogger();
     log.trace("Handling error on main()");

--- a/packages/shortest/src/cli/commands/shortest.test.ts
+++ b/packages/shortest/src/cli/commands/shortest.test.ts
@@ -71,6 +71,12 @@ describe("shortest command", () => {
     expect(
       shortestCommand.options.find((opt) => opt.long === "--no-cache"),
     ).toBeDefined();
+    expect(
+      shortestCommand.options.find((opt) => opt.long === "--report"),
+    ).toBeDefined();
+    expect(
+      shortestCommand.options.find((opt) => opt.long === "--report-dir"),
+    ).toBeDefined();
   });
 
   test("shortestCommand calls executeCommand with correct parameters", async () => {
@@ -101,7 +107,14 @@ describe("shortest command", () => {
 
   test("executeTestRunnerCommand executes test runner with correct options", async () => {
     await shortestCommand.parseAsync(
-      ["test-file.ts:123", "--headless", "--no-cache"],
+      [
+        "test-file.ts:123",
+        "--headless",
+        "--no-cache",
+        "--report",
+        "--report-dir",
+        "artifacts/reports",
+      ],
       { from: "user" },
     );
 
@@ -121,9 +134,60 @@ describe("shortest command", () => {
     expect(purgeLegacyScreenshots).toHaveBeenCalled();
 
     expect(TestRunner).toHaveBeenCalled();
+    expect(TestRunner).toHaveBeenCalledWith(
+      process.cwd(),
+      { testPattern: "test-pattern" },
+      {
+        report: {
+          enabled: true,
+          outputDir: "artifacts/reports",
+        },
+      },
+    );
     expect(mockInitialize).toHaveBeenCalled();
     expect(mockExecute).toHaveBeenCalledWith("test-pattern", 123);
 
     expect(cleanUpCache).toHaveBeenCalled();
+  });
+
+  test("passes default disabled report options to test runner", async () => {
+    await shortestCommand.parseAsync(["test-file.ts"], { from: "user" });
+
+    const callback = vi.mocked(executeCommand).mock.calls[0][2];
+
+    await callback({});
+
+    expect(TestRunner).toHaveBeenCalledWith(
+      process.cwd(),
+      { testPattern: "test-pattern" },
+      {
+        report: {
+          enabled: false,
+          outputDir: ".shortest/reports",
+        },
+      },
+    );
+  });
+
+  test("accepts report-dir without enabling reports", async () => {
+    await shortestCommand.parseAsync(
+      ["test-file.ts", "--report-dir", "custom-reports"],
+      { from: "user" },
+    );
+
+    const callback = vi.mocked(executeCommand).mock.calls[0][2];
+
+    await callback({});
+
+    expect(TestRunner).toHaveBeenCalledWith(
+      process.cwd(),
+      { testPattern: "test-pattern" },
+      {
+        report: {
+          enabled: false,
+          outputDir: "custom-reports",
+        },
+      },
+    );
   });
 });

--- a/packages/shortest/src/cli/commands/shortest.ts
+++ b/packages/shortest/src/cli/commands/shortest.ts
@@ -52,6 +52,12 @@ shortestCommand
     cliOptionsSchema.shape.baseUrl._def.defaultValue(),
   )
   .option("--no-cache", "Disable test action caching")
+  .option("--report", "Write redacted failure reports for failed runs")
+  .option(
+    "--report-dir <path>",
+    "Directory for redacted failure reports",
+    ".shortest/reports",
+  )
   .argument(
     "[test-pattern]",
     "Test pattern to run",
@@ -96,7 +102,12 @@ const executeTestRunnerCommand = async (testPattern: string, options: any) => {
 
   try {
     log.trace("Initializing TestRunner");
-    const runner = new TestRunner(process.cwd(), config);
+    const runner = new TestRunner(process.cwd(), config, {
+      report: {
+        enabled: Boolean(options.report),
+        outputDir: options.reportDir ?? ".shortest/reports",
+      },
+    });
     await runner.initialize();
     const success = await runner.execute(config.testPattern, lineNumber);
     process.exitCode = success ? 0 : 1;

--- a/packages/shortest/src/core/runner/index.test.ts
+++ b/packages/shortest/src/core/runner/index.test.ts
@@ -1,0 +1,137 @@
+import path from "path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TestRunner } from ".";
+import { createTestCase } from "@/core/runner/test-case";
+import { TestRun } from "@/core/runner/test-run";
+import { writeFailureReport } from "@/report/failure-report-writer";
+
+vi.mock("@/report/failure-report-writer", () => ({
+  writeFailureReport: vi.fn(),
+}));
+
+vi.mock("@/log", () => ({
+  Log: vi.fn().mockImplementation(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    resetGroup: vi.fn(),
+    setGroup: vi.fn(),
+  })),
+  getLogger: vi.fn(() => ({
+    config: {},
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    resetGroup: vi.fn(),
+    setGroup: vi.fn(),
+    trace: vi.fn(),
+  })),
+}));
+
+describe("TestRunner failure reports", () => {
+  const config = {
+    ai: {
+      apiKey: "test-key",
+      model: "claude-4-sonnet-20250514",
+      provider: "anthropic",
+    },
+    baseUrl: "https://example.com",
+    browser: {},
+    caching: { enabled: true },
+    headless: true,
+    testPattern: "**/*.test.ts",
+  } as any;
+
+  const createRun = (status: "failed" | "passed") => {
+    const testCase = createTestCase({
+      filePath: "tests/login.test.ts",
+      name: "Login test",
+    });
+    const testRun = TestRun.create(testCase);
+    testRun.markRunning();
+
+    if (status === "failed") {
+      testRun.markFailed({ reason: "password=hunter2" });
+    } else {
+      testRun.markPassed({ reason: "ok" });
+    }
+
+    return testRun;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not write reports when disabled", async () => {
+    const runner = new TestRunner("/repo", config, {
+      report: { enabled: false, outputDir: "reports" },
+    });
+
+    await (runner as any).writeFailureReport(createRun("failed"));
+
+    expect(writeFailureReport).not.toHaveBeenCalled();
+  });
+
+  it("does not write reports for passed tests", async () => {
+    const runner = new TestRunner("/repo", config, {
+      report: { enabled: true, outputDir: "reports" },
+    });
+
+    await (runner as any).writeFailureReport(createRun("passed"));
+
+    expect(writeFailureReport).not.toHaveBeenCalled();
+  });
+
+  it("writes reports for failed tests and prints the report path", async () => {
+    vi.mocked(writeFailureReport).mockResolvedValue("reports/run.md");
+
+    const runner = new TestRunner("/repo", config, {
+      report: { enabled: true, outputDir: "reports" },
+    });
+    const reporterInfo = vi
+      .spyOn((runner as any).reporter, "info")
+      .mockImplementation(() => undefined);
+    const testRun = createRun("failed");
+
+    await (runner as any).writeFailureReport(testRun);
+
+    expect(writeFailureReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: "tests/login.test.ts",
+        reason: "password=hunter2",
+        runId: testRun.runId,
+        screenshotSourceDir: path.join(
+          "/repo",
+          ".shortest",
+          "cache",
+          testRun.runId,
+        ),
+        testName: "Login test",
+      }),
+      {
+        cwd: "/repo",
+        enabled: true,
+        outputDir: "reports",
+      },
+    );
+    expect(reporterInfo).toHaveBeenCalledWith(
+      "Failure report written: reports/run.md",
+    );
+  });
+
+  it("reports writer failures without throwing", async () => {
+    vi.mocked(writeFailureReport).mockRejectedValue(new Error("disk full"));
+
+    const runner = new TestRunner("/repo", config, {
+      report: { enabled: true, outputDir: "reports" },
+    });
+    const reporterError = vi
+      .spyOn((runner as any).reporter, "error")
+      .mockImplementation(() => undefined);
+
+    await expect(
+      (runner as any).writeFailureReport(createRun("failed")),
+    ).resolves.toBeUndefined();
+    expect(reporterError).toHaveBeenCalledWith("Failure report", "disk full");
+  });
+});

--- a/packages/shortest/src/core/runner/index.ts
+++ b/packages/shortest/src/core/runner/index.ts
@@ -1,3 +1,4 @@
+import { join } from "path";
 import { pathToFileURL } from "url";
 import { glob } from "glob";
 import {
@@ -21,6 +22,8 @@ import { TestReporter } from "@/core/runner/test-reporter";
 import { TestRun } from "@/core/runner/test-run";
 import { TestRunRepository } from "@/core/runner/test-run-repository";
 import { getLogger, Log } from "@/log";
+import { writeFailureReport as writeFailureReportFile } from "@/report/failure-report-writer";
+import type { FailureReportOptions } from "@/report/types";
 import {
   TestContext,
   InternalActionEnum,
@@ -45,6 +48,10 @@ export const FileResultSchema = z.object({
 });
 export type FileResult = z.infer<typeof FileResultSchema>;
 
+interface TestRunnerOptions {
+  report?: FailureReportOptions;
+}
+
 export class TestRunner {
   private config: ShortestStrictConfig;
   private cwd: string;
@@ -54,10 +61,16 @@ export class TestRunner {
   private testContext: TestContext | null = null;
   private testFileContext: TestFileContext | null = null;
   private log: Log;
+  private options: TestRunnerOptions;
 
-  constructor(cwd: string, config: ShortestStrictConfig) {
+  constructor(
+    cwd: string,
+    config: ShortestStrictConfig,
+    options: TestRunnerOptions = {},
+  ) {
     this.config = config;
     this.cwd = cwd;
+    this.options = options;
     this.compiler = new TestCompiler();
     this.reporter = new TestReporter();
     this.log = getLogger();
@@ -414,14 +427,13 @@ export class TestRunner {
             await hook(testContext);
           }
 
-          await TestRunRepository.getRepositoryForTestCase(testCase).saveRun(
-            testRun,
-          );
+          const repository =
+            TestRunRepository.getRepositoryForTestCase(testCase);
+          await repository.saveRun(testRun);
+          await this.writeFailureReport(testRun);
 
           try {
-            await TestRunRepository.getRepositoryForTestCase(
-              testCase,
-            ).applyRetentionPolicy();
+            await repository.applyRetentionPolicy();
           } catch (error) {
             this.log.error(
               "Failed to apply retention policy",
@@ -544,5 +556,43 @@ export class TestRunner {
     if (this.testContext) return this.testContext;
 
     return { ...assertDefined(this.testFileContext), testRun };
+  }
+
+  private async writeFailureReport(testRun: TestRun): Promise<void> {
+    const reportOptions = this.options.report ?? {
+      enabled: false,
+      outputDir: ".shortest/reports",
+    };
+
+    if (!reportOptions.enabled || testRun.status !== "failed") return;
+
+    try {
+      const reportPath = await writeFailureReportFile(
+        {
+          runId: testRun.runId,
+          testName: testRun.testCase.name,
+          filePath: testRun.testCase.filePath,
+          reason: testRun.reason,
+          tokenUsage: testRun.tokenUsage,
+          steps: testRun.getSteps(),
+          screenshotSourceDir: join(
+            this.cwd,
+            ".shortest",
+            "cache",
+            testRun.runId,
+          ),
+        },
+        { ...reportOptions, cwd: this.cwd },
+      );
+
+      if (reportPath) {
+        this.reporter.info(`Failure report written: ${reportPath}`);
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unknown report error";
+      this.log.error("Failed to write failure report", getErrorDetails(error));
+      this.reporter.error("Failure report", message);
+    }
   }
 }

--- a/packages/shortest/src/core/runner/test-reporter.ts
+++ b/packages/shortest/src/core/runner/test-reporter.ts
@@ -115,6 +115,10 @@ export class TestReporter {
     this.reporterLog.error(pc.red(`${context}: ${message}`));
   }
 
+  info(message: string) {
+    this.reporterLog.info(message);
+  }
+
   reportAssertion(
     step: string,
     status: "passed" | "failed",

--- a/packages/shortest/src/report/failure-report-writer.test.ts
+++ b/packages/shortest/src/report/failure-report-writer.test.ts
@@ -1,0 +1,121 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { writeFailureReport } from "./failure-report-writer";
+import type { FailureReportInput } from "./types";
+
+const input: FailureReportInput = {
+  runId: "Run ABC 123",
+  testName: "Login",
+  filePath: "app/login.test.ts",
+  reason: "Bad token ghp_abcdefghijklmnopqrstuvwxyz1234567890",
+  steps: [],
+};
+
+describe("writeFailureReport", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "shortest-report-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { force: true, recursive: true });
+  });
+
+  it("returns null when reports are disabled", async () => {
+    await expect(
+      writeFailureReport(input, {
+        cwd: tempDir,
+        enabled: false,
+        outputDir: "reports",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("writes redacted markdown with a safe run id file name", async () => {
+    const reportPath = await writeFailureReport(input, {
+      cwd: tempDir,
+      enabled: true,
+      outputDir: "reports",
+    });
+
+    expect(reportPath).toBe("reports/run-abc-123.md");
+
+    const content = await fs.readFile(path.join(tempDir, reportPath!), "utf-8");
+    expect(content).toContain("# Shortest failure report");
+    expect(content).not.toContain("ghp_");
+    expect(content).toContain("[REDACTED:token]");
+  });
+
+  it("copies screenshots into the report bundle and links them", async () => {
+    const screenshotSourceDir = path.join(tempDir, "cache", "run");
+    await fs.mkdir(screenshotSourceDir, { recursive: true });
+    await fs.writeFile(
+      path.join(screenshotSourceDir, "screenshot-2026.png"),
+      "fake image",
+    );
+    await fs.writeFile(
+      path.join(screenshotSourceDir, "not-a-screenshot.txt"),
+      "x",
+    );
+
+    const reportPath = await writeFailureReport(
+      {
+        ...input,
+        screenshotSourceDir,
+      },
+      {
+        cwd: tempDir,
+        enabled: true,
+        outputDir: "reports",
+      },
+    );
+
+    const copiedScreenshotPath = path.join(
+      tempDir,
+      "reports",
+      "run-abc-123",
+      "screenshots",
+      "screenshot-2026.png",
+    );
+    const content = await fs.readFile(path.join(tempDir, reportPath!), "utf-8");
+
+    await expect(fs.readFile(copiedScreenshotPath, "utf-8")).resolves.toBe(
+      "fake image",
+    );
+    expect(content).toContain(
+      "![Screenshot 1](run-abc-123/screenshots/screenshot-2026.png)",
+    );
+    await expect(
+      fs.readFile(
+        path.join(
+          tempDir,
+          "reports",
+          "run-abc-123",
+          "screenshots",
+          "not-a-screenshot.txt",
+        ),
+        "utf-8",
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("handles missing screenshot directories", async () => {
+    const reportPath = await writeFailureReport(
+      {
+        ...input,
+        screenshotSourceDir: path.join(tempDir, "missing"),
+      },
+      {
+        cwd: tempDir,
+        enabled: true,
+        outputDir: "reports",
+      },
+    );
+
+    const content = await fs.readFile(path.join(tempDir, reportPath!), "utf-8");
+    expect(content).toContain("No screenshots recorded.");
+  });
+});

--- a/packages/shortest/src/report/failure-report-writer.ts
+++ b/packages/shortest/src/report/failure-report-writer.ts
@@ -1,0 +1,123 @@
+import fs from "fs/promises";
+import path from "path";
+import { renderFailureReport } from "./markdown";
+import type {
+  FailureReportInput,
+  FailureReportOptions,
+  ScreenshotAttachment,
+} from "./types";
+
+const SCREENSHOT_FILE_PATTERN = /^screenshot-.*\.(png|jpe?g|webp)$/i;
+
+const safeFileName = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 120) || "failure-report";
+
+const toDisplayPath = (filePath: string, cwd: string): string => {
+  const relativePath = path.relative(cwd, filePath);
+
+  return relativePath &&
+    !relativePath.startsWith("..") &&
+    !path.isAbsolute(relativePath)
+    ? relativePath
+    : filePath;
+};
+
+const readScreenshotFileNames = async (
+  screenshotSourceDir?: string,
+): Promise<string[]> => {
+  if (!screenshotSourceDir) return [];
+
+  try {
+    const entries = await fs.readdir(screenshotSourceDir, {
+      withFileTypes: true,
+    });
+
+    return entries
+      .filter(
+        (entry) => entry.isFile() && SCREENSHOT_FILE_PATTERN.test(entry.name),
+      )
+      .map((entry) => entry.name)
+      .sort();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+
+    throw error;
+  }
+};
+
+const copyScreenshots = async ({
+  reportDir,
+  safeRunId,
+  screenshotSourceDir,
+}: {
+  reportDir: string;
+  safeRunId: string;
+  screenshotSourceDir?: string;
+}): Promise<ScreenshotAttachment[]> => {
+  const screenshotFileNames =
+    await readScreenshotFileNames(screenshotSourceDir);
+  if (screenshotFileNames.length === 0 || !screenshotSourceDir) return [];
+
+  const screenshotDir = path.join(reportDir, safeRunId, "screenshots");
+  await fs.mkdir(screenshotDir, { recursive: true });
+
+  const screenshots: ScreenshotAttachment[] = [];
+  for (const fileName of screenshotFileNames) {
+    const sourcePath = path.join(screenshotSourceDir, fileName);
+    const destinationPath = path.join(screenshotDir, fileName);
+    await fs.copyFile(sourcePath, destinationPath);
+
+    screenshots.push({
+      fileName,
+      markdownPath: path.posix.join(safeRunId, "screenshots", fileName),
+    });
+  }
+
+  return screenshots;
+};
+
+const writeFileAtomically = async (
+  filePath: string,
+  content: string,
+): Promise<void> => {
+  const tempPath = path.join(
+    path.dirname(filePath),
+    `.tmp-${process.pid}-${Date.now()}-${path.basename(filePath)}`,
+  );
+
+  try {
+    await fs.writeFile(tempPath, content, "utf-8");
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true });
+    throw error;
+  }
+};
+
+export const writeFailureReport = async (
+  input: FailureReportInput,
+  options: FailureReportOptions,
+): Promise<string | null> => {
+  if (!options.enabled) return null;
+
+  const cwd = options.cwd ?? process.cwd();
+  const reportDir = path.resolve(cwd, options.outputDir);
+  const safeRunId = safeFileName(input.runId);
+  const reportPath = path.join(reportDir, `${safeRunId}.md`);
+
+  await fs.mkdir(reportDir, { recursive: true });
+
+  const screenshots = await copyScreenshots({
+    reportDir,
+    safeRunId,
+    screenshotSourceDir: input.screenshotSourceDir,
+  });
+  const report = renderFailureReport({ ...input, screenshots });
+  await writeFileAtomically(reportPath, report);
+
+  return toDisplayPath(reportPath, cwd);
+};

--- a/packages/shortest/src/report/markdown.test.ts
+++ b/packages/shortest/src/report/markdown.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import { renderFailureReport } from "./markdown";
+import type { FailureReportInput } from "./types";
+
+const input: FailureReportInput = {
+  runId: "2026-05-08T16-12-03-abc123",
+  testName: "Login to the app",
+  filePath: "app/login.test.ts",
+  reason:
+    "Failed with password=hunter2 and token ghp_abcdefghijklmnopqrstuvwxyz1234567890",
+  tokenUsage: {
+    promptTokens: 1000,
+    completionTokens: 250,
+    totalTokens: 1250,
+  },
+  steps: [
+    {
+      reasoning: "Need to type the user password",
+      action: {
+        type: "tool_use",
+        name: "type" as any,
+        input: { action: "type", text: "hunter2" } as any,
+      },
+      timestamp: 1,
+      result: "Typed: hunter2",
+    },
+  ],
+  screenshots: [
+    {
+      fileName: "screenshot-1.png",
+      markdownPath: "run/screenshots/screenshot-1.png",
+    },
+  ],
+};
+
+describe("renderFailureReport", () => {
+  it("renders test metadata, failure reason, and token usage", () => {
+    const report = renderFailureReport(input);
+
+    expect(report).toContain("# Shortest failure report");
+    expect(report).toContain("- Name: Login to the app");
+    expect(report).toContain("- File: app/login.test.ts");
+    expect(report).toContain("- Run: 2026-05-08T16-12-03-abc123");
+    expect(report).toContain("- Prompt: 1,000");
+    expect(report).toContain("- Completion: 250");
+    expect(report).toContain("- Total: 1,250");
+  });
+
+  it("redacts sensitive failure and step text", () => {
+    const report = renderFailureReport(input);
+
+    expect(report).not.toContain("hunter2");
+    expect(report).not.toContain("ghp_");
+    expect(report).toContain("[REDACTED:password]");
+    expect(report).toContain("[REDACTED:typed-text]");
+    expect(report).toContain("typed-text:");
+  });
+
+  it("redacts typed text when repeated in reasoning and failure reason", () => {
+    const report = renderFailureReport({
+      ...input,
+      reason: "The login failed after entering hunter2",
+      steps: [
+        {
+          reasoning: "I will type hunter2 into the password field",
+          action: {
+            type: "tool_use",
+            name: "type" as any,
+            input: { action: "type", text: "hunter2" } as any,
+          },
+          timestamp: 1,
+          result: "The field contains hunter2",
+        },
+      ],
+    });
+
+    expect(report).not.toContain("hunter2");
+    expect(report).toContain("[REDACTED:typed-text]");
+    expect(report).toContain("typed-text:");
+  });
+
+  it("redacts sensitive object values when repeated outside action input", () => {
+    const report = renderFailureReport({
+      ...input,
+      reason: "The API returned a failure for magic-secret",
+      steps: [
+        {
+          reasoning: "Send auth payload",
+          action: {
+            type: "tool_use",
+            name: "navigate" as any,
+            input: {
+              action: "navigate",
+              auth: { token: "magic-secret" },
+            } as any,
+          },
+          timestamp: 1,
+          result: "magic-secret was rejected",
+        },
+      ],
+    });
+
+    expect(report).not.toContain("magic-secret");
+    expect(report).toContain("[REDACTED:authorization]");
+  });
+
+  it("escapes dynamic Markdown in failure and step text", () => {
+    const report = renderFailureReport({
+      ...input,
+      reason: "Broken ![leak](https://example.com/?token=abc)",
+      steps: [
+        {
+          reasoning: "See <img src=x> and [token](https://x.test/?a=b)",
+          action: {
+            type: "tool_use",
+            name: "click" as any,
+            input: { action: "click" } as any,
+          },
+          timestamp: 1,
+          result: "Rendered **bold** output",
+        },
+      ],
+      screenshots: [],
+    });
+
+    expect(report).toContain("```txt\nBroken");
+    expect(report).toContain("https://example.com/?[redacted]");
+    expect(report).toContain("&lt;img src=x&gt;");
+    expect(report).toContain("[token]\\(");
+    expect(report).toContain("\\*\\*bold\\*\\*");
+  });
+
+  it("does not include base64 image data", () => {
+    const report = renderFailureReport({
+      ...input,
+      steps: [
+        {
+          reasoning: "Screenshot",
+          action: {
+            type: "tool_use",
+            name: "screenshot" as any,
+            input: { action: "screenshot" } as any,
+          },
+          timestamp: 1,
+          result: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+        },
+      ],
+    });
+
+    expect(report).not.toContain("iVBORw0KGgo");
+    expect(report).toContain("[REDACTED:base64-image]");
+  });
+
+  it("renders only the last 10 steps", () => {
+    const steps = Array.from({ length: 12 }, (_, index) => ({
+      reasoning: `step-${index.toString().padStart(2, "0")}`,
+      action: {
+        type: "tool_use" as const,
+        name: "sleep" as any,
+        input: { action: "sleep", duration: index } as any,
+      },
+      timestamp: index,
+      result: `result-${index.toString().padStart(2, "0")}`,
+    }));
+
+    const report = renderFailureReport({ ...input, steps });
+
+    expect(report).toContain("Showing last 10 of 12 steps.");
+    expect(report).not.toContain("result-00");
+    expect(report).not.toContain("result-01");
+    expect(report).toContain("result-11");
+  });
+
+  it("renders screenshot embeds and links without raw bytes", () => {
+    const report = renderFailureReport({
+      ...input,
+      screenshots: Array.from({ length: 6 }, (_, index) => ({
+        fileName: `screenshot-${index}.png`,
+        markdownPath: `run/screenshots/screenshot-${index}.png`,
+      })),
+    });
+
+    expect(report).toContain("Screenshots are included for debugging");
+    expect(report).toContain(
+      "![Screenshot 1](run/screenshots/screenshot-1.png)",
+    );
+    expect(report).not.toContain(
+      "![Screenshot 1](run/screenshots/screenshot-0.png)",
+    );
+    expect(report).toContain(
+      "- [screenshot-0.png](run/screenshots/screenshot-0.png)",
+    );
+    expect(report).toContain(
+      "- [screenshot-5.png](run/screenshots/screenshot-5.png)",
+    );
+  });
+
+  it("renders an empty screenshot message", () => {
+    const report = renderFailureReport({ ...input, screenshots: [] });
+
+    expect(report).toContain("No screenshots recorded.");
+  });
+
+  it("is deterministic for the same input", () => {
+    expect(renderFailureReport(input)).toBe(renderFailureReport(input));
+  });
+});

--- a/packages/shortest/src/report/markdown.ts
+++ b/packages/shortest/src/report/markdown.ts
@@ -1,0 +1,360 @@
+import {
+  mergeRedactionSummaries,
+  redactKnownLiterals,
+  redactString,
+  redactValue,
+} from "./redact";
+import type {
+  FailureReportInput,
+  RedactionKind,
+  RedactionSummary,
+  ScreenshotAttachment,
+} from "./types";
+import { InternalActionEnum } from "@/types/browser";
+import type { CacheAction, CacheStep } from "@/types/cache";
+
+const MAX_STEPS = 10;
+const MAX_EMBEDDED_SCREENSHOTS = 5;
+const MAX_INLINE_LENGTH = 300;
+const NUMBER_FORMATTER = new Intl.NumberFormat("en-US");
+const SENSITIVE_LITERAL_KEY_PATTERN =
+  /(password|passwd|secret|token|api[_-]?key|authorization|auth|cookie|session|otp|totp|base64[_-]?image|typed[_-]?text)/i;
+
+const formatNumber = (value: number | undefined): string =>
+  value === undefined ? "0" : NUMBER_FORMATTER.format(value);
+
+const truncate = (value: string, maxLength = MAX_INLINE_LENGTH): string =>
+  value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
+
+const normalizeInline = (value: string): string =>
+  truncate(
+    value
+      .replace(/\r\n/g, "\n")
+      .replace(/\r/g, "\n")
+      .replace(/\s+/g, " ")
+      .trim(),
+  );
+
+const normalizeBlock = (value: string): string =>
+  value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
+
+const escapeMarkdownInline = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/([\\`*_{}()#+!|])/g, "\\$1");
+
+const fencedCodeBlock = (value: string): string => {
+  const normalized = normalizeBlock(value);
+  const longestFence =
+    normalized
+      .match(/`{3,}/g)
+      ?.reduce((max, fence) => Math.max(max, fence.length), 2) ?? 2;
+  const fence = "`".repeat(longestFence + 1);
+
+  return `${fence}txt\n${normalized}\n${fence}`;
+};
+
+const markdownLinkPath = (value: string): string =>
+  value
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+
+const formatSummary = (summary: RedactionSummary): string => {
+  const entries = Object.entries(summary).filter(([, count]) => count);
+  if (entries.length === 0) return "- none";
+
+  return entries
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([kind, count]) => `- ${kind}: ${count}`)
+    .join("\n");
+};
+
+const formatJson = (value: unknown): string => {
+  try {
+    return escapeMarkdownInline(normalizeInline(JSON.stringify(value)));
+  } catch {
+    return escapeMarkdownInline(normalizeInline(String(value)));
+  }
+};
+
+const getActionName = (action: CacheAction): string =>
+  action.input?.action ?? action.name ?? "tool";
+
+const summarizeAction = (
+  action: CacheAction | null,
+): { text: string; summary: RedactionSummary } => {
+  if (!action) return { text: "text", summary: {} };
+
+  const actionName = getActionName(action);
+  const input = action.input ?? {};
+
+  if (
+    actionName === InternalActionEnum.TYPE &&
+    typeof input.text === "string"
+  ) {
+    const redacted = redactString(input.text, "typed-text");
+
+    return {
+      text: `${escapeMarkdownInline(actionName)} - Typed: ${escapeMarkdownInline(redacted.value)}`,
+      summary: redacted.summary,
+    };
+  }
+
+  if (
+    actionName === InternalActionEnum.NAVIGATE &&
+    typeof input.url === "string"
+  ) {
+    const redacted = redactString(input.url, "url");
+
+    return {
+      text: `${escapeMarkdownInline(actionName)} - URL: ${escapeMarkdownInline(normalizeInline(redacted.value))}`,
+      summary: redacted.summary,
+    };
+  }
+
+  const coordinate = input.coordinate ?? input.coordinates;
+  if (Array.isArray(coordinate) && coordinate.length >= 2) {
+    return {
+      text: `${escapeMarkdownInline(actionName)} - Coordinate: (${escapeMarkdownInline(String(coordinate[0]))}, ${escapeMarkdownInline(String(coordinate[1]))})`,
+      summary: {},
+    };
+  }
+
+  const redactedInput = redactValue(input);
+  const inputText =
+    Object.keys(input).length > 0
+      ? ` - Input: ${formatJson(redactedInput.value)}`
+      : "";
+
+  return {
+    text: `${escapeMarkdownInline(actionName)}${inputText}`,
+    summary: redactedInput.summary,
+  };
+};
+
+interface SensitiveLiteral {
+  value: string;
+  kind: RedactionKind;
+}
+
+const getSensitiveLiteralKind = (keyHint: string): RedactionKind | null => {
+  if (!SENSITIVE_LITERAL_KEY_PATTERN.test(keyHint)) return null;
+
+  if (/base64[_-]?image/i.test(keyHint)) return "base64-image";
+  if (/typed[_-]?text/i.test(keyHint)) return "typed-text";
+  if (/password|passwd/i.test(keyHint)) return "password";
+  if (/otp|totp/i.test(keyHint)) return "totp";
+  if (/cookie|session/i.test(keyHint)) return "cookie";
+  if (/authorization|auth/i.test(keyHint)) return "authorization";
+  if (/secret|api[_-]?key/i.test(keyHint)) return "secret-key";
+
+  return "token";
+};
+
+const collectStringLeaves = (
+  value: unknown,
+  kind: RedactionKind,
+): SensitiveLiteral[] => {
+  if (typeof value === "string") return [{ value, kind }];
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectStringLeaves(item, kind));
+  }
+  if (value && typeof value === "object") {
+    return Object.values(value).flatMap((child) =>
+      collectStringLeaves(child, kind),
+    );
+  }
+
+  return [];
+};
+
+const collectSensitiveLiteralsFromValue = (
+  value: unknown,
+  keyHint?: string,
+): SensitiveLiteral[] => {
+  const keyKind = keyHint ? getSensitiveLiteralKind(keyHint) : null;
+  if (keyKind) return collectStringLeaves(value, keyKind);
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectSensitiveLiteralsFromValue(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.entries(value).flatMap(([key, child]) =>
+      collectSensitiveLiteralsFromValue(child, key),
+    );
+  }
+
+  return [];
+};
+
+const collectSensitiveLiterals = (steps: CacheStep[]): SensitiveLiteral[] =>
+  steps.flatMap((step) => {
+    const input = step.action?.input;
+    if (!input) return [];
+
+    const literals = collectSensitiveLiteralsFromValue(input);
+    if (
+      input.action === InternalActionEnum.TYPE &&
+      typeof input.text === "string"
+    ) {
+      literals.push({ value: input.text, kind: "typed-text" });
+    }
+
+    return literals;
+  });
+
+const redactReportText = (
+  value: string,
+  literals: SensitiveLiteral[],
+  keyHint?: string,
+): RedactedString => {
+  const redacted = redactString(value, keyHint);
+  const literalRedaction = redactKnownLiterals(redacted.value, literals);
+
+  return {
+    value: literalRedaction.value,
+    summary: mergeRedactionSummaries(
+      redacted.summary,
+      literalRedaction.summary,
+    ),
+  };
+};
+
+interface RedactedString {
+  value: string;
+  summary: RedactionSummary;
+}
+
+const renderStep = (
+  step: CacheStep,
+  index: number,
+  sensitiveLiterals: SensitiveLiteral[],
+): { lines: string[]; summary: RedactionSummary } => {
+  const action = summarizeAction(step.action);
+  const isTypedTextAction =
+    step.action?.input?.action === InternalActionEnum.TYPE;
+  const reasoning = redactReportText(step.reasoning ?? "", sensitiveLiterals);
+  const result = redactReportText(
+    step.result ?? "",
+    sensitiveLiterals,
+    isTypedTextAction ? "typed-text" : undefined,
+  );
+  const summary = mergeRedactionSummaries(
+    action.summary,
+    reasoning.summary,
+    result.summary,
+  );
+  const lines = [`${index}. ${action.text}`];
+
+  if (reasoning.value) {
+    lines.push(
+      `   - Reasoning: ${escapeMarkdownInline(normalizeInline(reasoning.value))}`,
+    );
+  }
+
+  if (result.value) {
+    lines.push(
+      `   - Result: ${escapeMarkdownInline(normalizeInline(result.value))}`,
+    );
+  }
+
+  return { lines, summary };
+};
+
+const renderScreenshots = (
+  screenshots: ScreenshotAttachment[] = [],
+): string[] => {
+  if (screenshots.length === 0) return ["No screenshots recorded."];
+
+  const embeddedScreenshots = screenshots.slice(-MAX_EMBEDDED_SCREENSHOTS);
+  const lines = [
+    "Screenshots are included for debugging and are not machine-redacted. Review them before sharing this report.",
+    "",
+    ...embeddedScreenshots.flatMap((screenshot, index) => [
+      `![Screenshot ${index + 1}](${markdownLinkPath(screenshot.markdownPath)})`,
+      "",
+    ]),
+    "All screenshots:",
+    ...screenshots.map(
+      (screenshot) =>
+        `- [${escapeMarkdownInline(screenshot.fileName)}](${markdownLinkPath(screenshot.markdownPath)})`,
+    ),
+  ];
+
+  return lines;
+};
+
+export const renderFailureReport = (input: FailureReportInput): string => {
+  const sensitiveLiterals = collectSensitiveLiterals(input.steps);
+  const testName = redactString(input.testName);
+  const filePath = redactString(input.filePath);
+  const runId = redactString(input.runId);
+  const reason = redactReportText(
+    input.reason ?? "No failure reason recorded",
+    sensitiveLiterals,
+  );
+  const steps = input.steps.slice(-MAX_STEPS);
+  let summary = mergeRedactionSummaries(
+    testName.summary,
+    filePath.summary,
+    runId.summary,
+    reason.summary,
+  );
+
+  const renderedSteps = steps.flatMap((step, index) => {
+    const rendered = renderStep(step, index + 1, sensitiveLiterals);
+    summary = mergeRedactionSummaries(summary, rendered.summary);
+
+    return rendered.lines;
+  });
+
+  const stepIntro =
+    input.steps.length > steps.length
+      ? `Showing last ${steps.length} of ${input.steps.length} steps.`
+      : `Showing ${steps.length} recorded step${steps.length === 1 ? "" : "s"}.`;
+
+  return [
+    "# Shortest failure report",
+    "",
+    "Generated by Shortest. Review text and screenshots before sharing.",
+    "",
+    "## Test",
+    "",
+    `- Name: ${escapeMarkdownInline(normalizeInline(testName.value))}`,
+    `- File: ${escapeMarkdownInline(normalizeInline(filePath.value))}`,
+    `- Run: ${escapeMarkdownInline(normalizeInline(runId.value))}`,
+    "- Status: failed",
+    "",
+    "## Failure",
+    "",
+    fencedCodeBlock(reason.value),
+    "",
+    "## Token usage",
+    "",
+    `- Prompt: ${formatNumber(input.tokenUsage?.promptTokens)}`,
+    `- Completion: ${formatNumber(input.tokenUsage?.completionTokens)}`,
+    `- Total: ${formatNumber(input.tokenUsage?.totalTokens)}`,
+    "",
+    "## Last recorded steps",
+    "",
+    stepIntro,
+    "",
+    ...(renderedSteps.length ? renderedSteps : ["No steps recorded."]),
+    "",
+    "## Screenshots",
+    "",
+    ...renderScreenshots(input.screenshots),
+    "",
+    "## Redactions",
+    "",
+    formatSummary(summary),
+    "",
+    "## Notes",
+    "",
+    "This report intentionally omits raw base64 image data, cookies, auth headers, and full cache JSON. Screenshot files are attached separately and are not machine-redacted.",
+    "",
+  ].join("\n");
+};

--- a/packages/shortest/src/report/redact.test.ts
+++ b/packages/shortest/src/report/redact.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  redactKnownLiterals,
+  redactString,
+  redactUrl,
+  redactValue,
+} from "./redact";
+
+describe("redactString", () => {
+  it("redacts Anthropic and OpenAI style API keys", () => {
+    const result = redactString(
+      "anthropic=sk-ant-api03-abcdefghijklmnopqrstuvwxyz openai=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890",
+    );
+
+    expect(result.value).not.toContain("sk-ant-api03");
+    expect(result.value).not.toContain("sk-proj");
+    expect(result.summary["secret-key"]).toBe(2);
+  });
+
+  it("redacts GitHub personal access tokens", () => {
+    const result = redactString(
+      "token ghp_abcdefghijklmnopqrstuvwxyz1234567890 and github_pat_11AAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    );
+
+    expect(result.value).not.toContain("ghp_");
+    expect(result.value).not.toContain("github_pat_");
+    expect(result.summary.token).toBe(2);
+  });
+
+  it("redacts bearer tokens and JWT-like values", () => {
+    const result = redactString(
+      "Authorization: Bearer abc.def.ghi jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature_value",
+    );
+
+    expect(result.value).not.toContain("Bearer abc.def.ghi");
+    expect(result.value).not.toContain("eyJhbGci");
+    expect(result.summary.authorization).toBe(1);
+    expect(result.summary.token).toBe(1);
+  });
+
+  it("redacts URL query strings and hashes", () => {
+    const result = redactUrl(
+      "Open https://example.com/login?token=abc#secret now",
+    );
+
+    expect(result.value).toBe("Open https://example.com/login?[redacted] now");
+    expect(result.summary["url-query"]).toBe(1);
+  });
+
+  it("redacts base64 image data", () => {
+    const result = redactString(
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+    );
+
+    expect(result.value).toBe("[REDACTED:base64-image]");
+    expect(result.summary["base64-image"]).toBe(1);
+  });
+
+  it("redacts password assignments in free text", () => {
+    const result = redactString("Login failed with password=hunter2");
+
+    expect(result.value).toBe(
+      "Login failed with password: [REDACTED:password]",
+    );
+    expect(result.summary.password).toBe(1);
+  });
+
+  it("preserves safe strings", () => {
+    const result = redactString("Clicked the submit button");
+
+    expect(result.value).toBe("Clicked the submit button");
+    expect(result.summary).toEqual({});
+  });
+});
+
+describe("redactKnownLiterals", () => {
+  it("redacts collected sensitive literals in surrounding text", () => {
+    const result = redactKnownLiterals(
+      "The login failed after typing hunter2 into the form",
+      [{ value: "hunter2", kind: "typed-text" }],
+    );
+
+    expect(result.value).toBe(
+      "The login failed after typing [REDACTED:typed-text] into the form",
+    );
+    expect(result.summary["typed-text"]).toBe(1);
+  });
+
+  it("ignores tiny literals to avoid noisy over-redaction", () => {
+    const result = redactKnownLiterals("Tap a button", [
+      { value: "a", kind: "typed-text" },
+    ]);
+
+    expect(result.value).toBe("Tap a button");
+    expect(result.summary).toEqual({});
+  });
+});
+
+describe("redactValue", () => {
+  it("redacts nested sensitive fields without mutating the original object", () => {
+    const original = {
+      payload: {
+        username: "sushi",
+        password: "hunter2",
+        headers: {
+          Authorization: "Bearer abc.def.ghi",
+          Cookie: "sid=secret",
+        },
+      },
+    };
+
+    const result = redactValue(original);
+
+    expect(result.value.payload.username).toBe("sushi");
+    expect(result.value.payload.password).toBe("[REDACTED:password]");
+    expect(result.value.payload.headers.Authorization).toBe(
+      "[REDACTED:authorization]",
+    );
+    expect(result.value.payload.headers.Cookie).toBe("[REDACTED:cookie]");
+    expect(result.summary.password).toBe(1);
+    expect(result.summary.authorization).toBe(1);
+    expect(result.summary.cookie).toBe(1);
+    expect(original.payload.password).toBe("hunter2");
+  });
+
+  it("redacts whole nested values under sensitive keys", () => {
+    const result = redactValue({
+      auth: {
+        scheme: "Bearer",
+        value: "abc.def.ghi",
+      },
+      cookies: [{ name: "sid", value: "secret" }],
+    });
+
+    expect(result.value.auth).toBe("[REDACTED:authorization]");
+    expect(result.value.cookies).toBe("[REDACTED:cookie]");
+    expect(result.summary.authorization).toBe(1);
+    expect(result.summary.cookie).toBe(1);
+  });
+
+  it("redacts TOTP, API key, token, session, and base64 image keys", () => {
+    const result = redactValue({
+      totpSecret: "JBSWY3DPEHPK3PXP",
+      api_key: "sk-ant-api03-abcdefghijklmnopqrstuvwxyz",
+      sessionToken: "abc123",
+      base64_image: "iVBORw0KGgoAAAANSUhEUgAAAAUA",
+    });
+
+    expect(result.value.totpSecret).toBe("[REDACTED:totp]");
+    expect(result.value.api_key).toBe("[REDACTED:secret-key]");
+    expect(result.value.sessionToken).toBe("[REDACTED:cookie]");
+    expect(result.value.base64_image).toBe("[REDACTED:base64-image]");
+  });
+
+  it("redacts typed text when explicitly hinted", () => {
+    const result = redactString("hunter2", "typed-text");
+
+    expect(result.value).toBe("[REDACTED:typed-text]");
+    expect(result.summary["typed-text"]).toBe(1);
+  });
+
+  it("redacts nested arrays and high entropy strings", () => {
+    const result = redactValue({
+      values: [
+        "safe",
+        "aZ9x".repeat(16),
+        { url: "https://example.com/path?secret=yes" },
+      ],
+    });
+
+    expect(result.value.values[0]).toBe("safe");
+    expect(result.value.values[1]).toBe("[REDACTED:high-entropy]");
+    expect(result.value.values[2]).toEqual({
+      url: "https://example.com/path?[redacted]",
+    });
+    expect(result.summary["high-entropy"]).toBe(1);
+    expect(result.summary["url-query"]).toBe(1);
+  });
+});

--- a/packages/shortest/src/report/redact.ts
+++ b/packages/shortest/src/report/redact.ts
@@ -1,0 +1,199 @@
+import type { Redacted, RedactionKind, RedactionSummary } from "./types";
+
+const SENSITIVE_KEY_PATTERN =
+  /(password|passwd|secret|token|api[_-]?key|authorization|auth|cookie|session|otp|totp|base64[_-]?image|typed[_-]?text)/i;
+
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"')\]]+/gi;
+const HIGH_ENTROPY_PATTERN =
+  /\b(?=[A-Za-z0-9+/_.=-]{48,}\b)(?=.*[A-Z])(?=.*[a-z])(?=.*\d)[A-Za-z0-9+/_.=-]+\b/g;
+
+const SECRET_PATTERNS: Array<{ kind: RedactionKind; pattern: RegExp }> = [
+  {
+    kind: "base64-image",
+    pattern: /data:image\/[a-z0-9.+-]+;base64,[A-Za-z0-9+/=]+/gi,
+  },
+  { kind: "secret-key", pattern: /sk-ant-[A-Za-z0-9_-]+/g },
+  { kind: "secret-key", pattern: /sk-proj-[A-Za-z0-9_-]+/g },
+  { kind: "secret-key", pattern: /\bsk-[A-Za-z0-9]{20,}\b/g },
+  { kind: "token", pattern: /\bghp_[A-Za-z0-9_]{20,}\b/g },
+  { kind: "token", pattern: /\bgithub_pat_[A-Za-z0-9_]+\b/g },
+  { kind: "authorization", pattern: /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi },
+  {
+    kind: "token",
+    pattern: /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g,
+  },
+  {
+    kind: "password",
+    pattern: /\b(pass(?:word|wd))\s*[:=]\s*["']?[^"',\s)]+/gi,
+  },
+];
+
+export const mergeRedactionSummaries = (
+  ...summaries: RedactionSummary[]
+): RedactionSummary =>
+  summaries.reduce<RedactionSummary>((merged, summary) => {
+    for (const [kind, count] of Object.entries(summary)) {
+      if (!count) continue;
+
+      const redactionKind = kind as RedactionKind;
+      merged[redactionKind] = (merged[redactionKind] ?? 0) + count;
+    }
+
+    return merged;
+  }, {});
+
+const increment = (summary: RedactionSummary, kind: RedactionKind): void => {
+  summary[kind] = (summary[kind] ?? 0) + 1;
+};
+
+const getSensitiveKeyKind = (keyHint?: string): RedactionKind | null => {
+  if (!keyHint || !SENSITIVE_KEY_PATTERN.test(keyHint)) return null;
+
+  if (/base64[_-]?image/i.test(keyHint)) return "base64-image";
+  if (/typed[_-]?text/i.test(keyHint)) return "typed-text";
+  if (/password|passwd/i.test(keyHint)) return "password";
+  if (/otp|totp/i.test(keyHint)) return "totp";
+  if (/cookie|session/i.test(keyHint)) return "cookie";
+  if (/authorization|auth/i.test(keyHint)) return "authorization";
+  if (/secret|api[_-]?key/i.test(keyHint)) return "secret-key";
+
+  return "token";
+};
+
+export const redactUrl = (value: string): Redacted<string> => {
+  const summary: RedactionSummary = {};
+  const redacted = value.replace(URL_PATTERN, (match) => {
+    try {
+      const url = new URL(match);
+      if (!url.search && !url.hash) return match;
+
+      url.search = "";
+      url.hash = "";
+      increment(summary, "url-query");
+
+      return `${url.toString()}?[redacted]`;
+    } catch {
+      return match;
+    }
+  });
+
+  return { value: redacted, summary };
+};
+
+export const redactString = (
+  value: string,
+  keyHint?: string,
+): Redacted<string> => {
+  const sensitiveKeyKind = getSensitiveKeyKind(keyHint);
+  if (sensitiveKeyKind) {
+    return {
+      value: `[REDACTED:${sensitiveKeyKind}]`,
+      summary: { [sensitiveKeyKind]: 1 },
+    };
+  }
+
+  let redacted = value;
+  let summary: RedactionSummary = {};
+
+  const urlRedaction = redactUrl(redacted);
+  redacted = urlRedaction.value;
+  summary = mergeRedactionSummaries(summary, urlRedaction.summary);
+
+  for (const { kind, pattern } of SECRET_PATTERNS) {
+    redacted = redacted.replace(pattern, (match) => {
+      increment(summary, kind);
+
+      if (kind === "password") {
+        const label = match.split(/[:=]/)[0].trim();
+        return `${label}: [REDACTED:password]`;
+      }
+
+      return `[REDACTED:${kind}]`;
+    });
+  }
+
+  redacted = redacted.replace(HIGH_ENTROPY_PATTERN, () => {
+    increment(summary, "high-entropy");
+    return "[REDACTED:high-entropy]";
+  });
+
+  return { value: redacted, summary };
+};
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const redactKnownLiterals = (
+  value: string,
+  literals: Array<{ value: string; kind: RedactionKind }>,
+): Redacted<string> => {
+  let redacted = value;
+  const summary: RedactionSummary = {};
+  const seen = new Set<string>();
+  const uniqueLiterals = literals
+    .map(({ value, kind }) => ({ value: value.trim(), kind }))
+    .filter(({ value }) => value.length >= 3)
+    .filter(({ value, kind }) => {
+      const key = `${kind}:${value}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+
+      return true;
+    })
+    .sort((a, b) => b.value.length - a.value.length);
+
+  for (const literal of uniqueLiterals) {
+    const pattern = new RegExp(escapeRegExp(literal.value), "g");
+    redacted = redacted.replace(pattern, () => {
+      increment(summary, literal.kind);
+
+      return `[REDACTED:${literal.kind}]`;
+    });
+  }
+
+  return { value: redacted, summary };
+};
+
+export const redactValue = <T>(value: T, keyHint?: string): Redacted<T> => {
+  if (typeof value === "string") {
+    return redactString(value, keyHint) as Redacted<T>;
+  }
+
+  const sensitiveKeyKind = getSensitiveKeyKind(keyHint);
+  if (sensitiveKeyKind) {
+    return {
+      value: `[REDACTED:${sensitiveKeyKind}]` as T,
+      summary: { [sensitiveKeyKind]: 1 },
+    };
+  }
+
+  if (Array.isArray(value)) {
+    const redactedItems: unknown[] = [];
+    let summary: RedactionSummary = {};
+
+    for (const item of value) {
+      const redacted = redactValue(item);
+      redactedItems.push(redacted.value);
+      summary = mergeRedactionSummaries(summary, redacted.summary);
+    }
+
+    return { value: redactedItems as T, summary };
+  }
+
+  if (value && typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    let summary: RedactionSummary = {};
+
+    for (const [key, child] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      const redacted = redactValue(child, key);
+      output[key] = redacted.value;
+      summary = mergeRedactionSummaries(summary, redacted.summary);
+    }
+
+    return { value: output as T, summary };
+  }
+
+  return { value, summary: {} };
+};

--- a/packages/shortest/src/report/types.ts
+++ b/packages/shortest/src/report/types.ts
@@ -1,0 +1,45 @@
+import type { TokenUsage } from "@/types/ai";
+import type { CacheStep } from "@/types/cache";
+
+export interface FailureReportOptions {
+  enabled: boolean;
+  outputDir: string;
+  cwd?: string;
+}
+
+export interface ScreenshotAttachment {
+  fileName: string;
+  markdownPath: string;
+}
+
+export interface FailureReportInput {
+  runId: string;
+  testName: string;
+  filePath: string;
+  reason?: string;
+  tokenUsage?: TokenUsage;
+  steps: CacheStep[];
+  screenshotSourceDir?: string;
+  screenshots?: ScreenshotAttachment[];
+}
+
+// eslint-disable-next-line zod/require-zod-schema-types
+export type RedactionKind =
+  | "authorization"
+  | "base64-image"
+  | "cookie"
+  | "high-entropy"
+  | "password"
+  | "secret-key"
+  | "token"
+  | "totp"
+  | "typed-text"
+  | "url-query";
+
+export interface RedactionSummary
+  extends Partial<Record<RedactionKind, number>> {}
+
+export interface Redacted<T> {
+  value: T;
+  summary: RedactionSummary;
+}


### PR DESCRIPTION
Failed Shortest runs currently leave the most useful debugging context in raw cache artifacts that are hard to share safely, and retention can remove failed-run screenshots before they are copied anywhere durable.
This adds an opt-in `--report` flow, configurable with `--report-dir`, that writes a local Markdown failure report, copies screenshot artifacts before retention, redacts sensitive text and known typed literals, escapes dynamic Markdown, and warns that screenshots are not machine-redacted.
Report-writing failures are non-fatal, and the CLI entrypoint now preserves `process.exitCode` so failed runs still exit non-zero after command handling.
Verified with `pnpm --dir packages/shortest test:unit`, `pnpm --dir packages/shortest build`, `pnpm lint`, `pnpm --dir packages/shortest cli --help`, a browser e2e subset, and a manual failed-run report smoke.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces sensitive-data handling (redaction heuristics and copied screenshots) and changes CLI exit behavior; failures are opt-in and report errors are swallowed, but mis-redaction or unreviewed screenshots could leak secrets if shared carelessly.
> 
> **Overview**
> Adds an **opt-in `--report` / `--report-dir`** flow so failed test runs can emit a **local Markdown bundle** (default `.shortest/reports`) with **best-effort text redaction**, **escaped dynamic Markdown**, and **screenshot files copied** from the run cache into the report (with explicit warnings that screenshots are not machine-redacted).
> 
> **`TestRunner`** now accepts report options, writes reports only for **failed** runs after persisting the run (before retention), and treats report I/O errors as **non-fatal**. The CLI **`bin`** exits with **`process.exitCode ?? 0`** so failed runs stay non-zero when commands set `exitCode` instead of forcing success.
> 
> Documentation in both READMEs describes the new flags and sharing cautions; unit tests cover CLI wiring, runner behavior, redaction, and report rendering/writing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c34d1f9a7bbe38f74c9288893ee9ec082e42033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->